### PR TITLE
Decouple tests from library

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,15 +36,8 @@ jobs:
         vcpkg install doctest
 
     - name: build the library
-      run: |
-        cmake -B build .
-        cmake --build build
+      run: make
 
     - name: build and run tests
-      run: |
-        cd test
-        cmake -B build .
-        cmake --build build
-        cd build
-        ctest
+      run: make test
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,8 +36,15 @@ jobs:
         vcpkg install doctest
 
     - name: build the library
-      run: make
+      run: |
+        cmake -B build .
+        cmake --build build
 
     - name: build and run tests
-      run: make test
+      run: |
+        cd test
+        cmake -B build .
+        cmake --build build
+        cd build
+        ctest
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,15 +35,9 @@ jobs:
         choco install openssl
         vcpkg install doctest
 
-    - name: configure
-      run: cmake -Bbuild -DBUILD_TESTS=ON -DCLANG_TIDY=ON .
+    - name: build the library
+      run: make
 
-    - name: build
-      run: cmake --build build --target SFrame
-
-    - name: test
-      run: |
-        cmake --build build --target SFrameTests
-        cd build
-        ctest
+    - name: build and run tests
+      run: make test
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
     - name: dependencies (ubuntu and macos)
       if: ${{ matrix.os == 'macos-latest' || matrix.os == 'ubuntu-latest' }}
       run: |
-        brew install pkgconfig doctest
+        brew install pkgconfig doctest clang-format
         brew reinstall openssl
     
     - name: dependencies (windows)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
     - name: dependencies (ubuntu and macos)
       if: ${{ matrix.os == 'macos-latest' || matrix.os == 'ubuntu-latest' }}
       run: |
-        brew install pkgconfig doctest clang-format
+        brew install pkgconfig doctest
         brew reinstall openssl
     
     - name: dependencies (windows)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,9 +39,3 @@ target_include_directories(SFrame
   PRIVATE
     ${OPENSSL_INCLUDE_DIR}
 )
-
-# Testing
-if(BUILD_TESTS)
-  enable_testing()
-  add_subdirectory(test)
-endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,6 @@ if(CLANG_TIDY)
 endif()
 
 # Library 
-
 file(GLOB_RECURSE headers CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/include/*.h")
 file(GLOB_RECURSE sources CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp") 
 
@@ -39,3 +38,8 @@ target_include_directories(SFrame
   PRIVATE
     ${OPENSSL_INCLUDE_DIR}
 )
+
+# Export package for local development access
+set(CMAKE_EXPORT_PACKAGE_REGISTRY ON)
+export(TARGETS SFrame FILE SFrameConfig.cmake NAMESPACE SFrame::)
+export(PACKAGE SFrame)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,8 +28,8 @@ file(GLOB_RECURSE headers CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/include
 file(GLOB_RECURSE sources CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp") 
 
 add_library(SFrame ${headers} ${sources})
-
-set_target_properties(SFrame PROPERTIES CXX_STANDARD 17)
+set_property(TARGET SFrame PROPERTY CXX_STANDARD 17)
+set_property(TARGET SFrame PROPERTY CXX_STANDARD_REQUIRED ON)
 
 target_include_directories(SFrame
   PUBLIC

--- a/Makefile
+++ b/Makefile
@@ -20,9 +20,11 @@ ${BUILD_DIR}: CMakeLists.txt
 
 clean:
 	cmake --build build --target clean
+	make -C test clean
 
 cclean:
 	rm -rf ${BUILD_DIR}
+	make -C test cclean
 
 format:
 	${CLANG_FORMAT} -i src/*.cpp

--- a/Makefile
+++ b/Makefile
@@ -13,10 +13,10 @@ test: all
 	make -C test test
 
 tidy:
-	cmake ${GENERATOR} -B${BUILD_DIR} -DCLANG_TIDY=ON .
+	cmake -B${BUILD_DIR} -DCLANG_TIDY=ON .
 
 ${BUILD_DIR}: CMakeLists.txt
-	cmake ${GENERATOR} -B${BUILD_DIR} .
+	cmake -B${BUILD_DIR} .
 
 clean:
 	cmake --build build --target clean

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,6 @@
 # This is just a convenience Makefile to avoid having to remember
 # all the CMake commands and their arguments.
 
-# choose: Ninja, Unix Makefiles, Xcode, or leave blank for default
-GENERATOR=-G Ninja
 BUILD_DIR=build
 CLANG_FORMAT=clang-format
 
@@ -21,7 +19,7 @@ ${BUILD_DIR}: CMakeLists.txt
 	cmake ${GENERATOR} -B${BUILD_DIR} .
 
 clean:
-	cd ${BUILD_DIR} && ninja clean
+	cmake --build build --target clean
 
 cclean:
 	rm -rf ${BUILD_DIR}

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ CLANG_FORMAT=clang-format
 
 .PHONY: all tidy test clean cclean format
 
-all: ${BUILD_DIR} format
+all: ${BUILD_DIR}
 	cmake --build ${BUILD_DIR}
 
 test: all

--- a/README.md
+++ b/README.md
@@ -23,14 +23,11 @@ A convenience Makefile is included to avoid the need to remember a bunch of
 CMake parameters.
 
 ```
-> make        # Configures all targets and builds the library
+> make        # Builds the library
 > make test   # Builds and runs tests
+> make format # Runs clang-format over the source
 ```
 
 ## Prerequisites
 
 You need openssl 1.1 or greater installed, C++ compiler, make, and cmake
-
-
-
-

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -4,16 +4,21 @@ project(SFrameTests
   LANGUAGES CXX
 )
 
-#Dependencies
-
+# Dependencies
 find_package(doctest REQUIRED)
 find_package(OpenSSL 1.1 REQUIRED)
 
-#Test Binary
+# SFrame
+set(SFRAME_INCLUDE_DIR ${PROJECT_SOURCE_DIR}/../include)
+set(SFRAME_BINARY_DIR ${PROJECT_SOURCE_DIR}/../build)
+
+# Test Binary
 
 file(GLOB sources CONFIGURE_DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/*.cpp)
 
 add_executable(SFrameTests ${sources})
+target_include_directories(SFrameTests PRIVATE ${SFRAME_INCLUDE_DIR})
+target_link_directories(SFrameTests PRIVATE ${SFRAME_BINARY_DIR})
 target_link_libraries(SFrameTests doctest::doctest SFrame OpenSSL::Crypto)
 
 set_target_properties(SFrameTests PROPERTIES CXX_STANDARD 17)
@@ -26,4 +31,5 @@ endif()
 
 # Enable CTest
 include(doctest)
+enable_testing()
 doctest_discover_tests(SFrameTests)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -14,11 +14,10 @@ find_package(OpenSSL 1.1 REQUIRED)
 file(GLOB sources CONFIGURE_DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/*.cpp)
 
 add_executable(SFrameTests ${sources})
-target_include_directories(SFrameTests PRIVATE ${SFRAME_INCLUDE_DIR})
-target_link_directories(SFrameTests PRIVATE ${SFRAME_BINARY_DIR})
 target_link_libraries(SFrameTests doctest::doctest SFrame::SFrame OpenSSL::Crypto)
 
-set_target_properties(SFrameTests PROPERTIES CXX_STANDARD 17)
+set_property(TARGET SFrameTests PROPERTY CXX_STANDARD 17)
+set_property(TARGET SFrameTests PROPERTY CXX_STANDARD_REQUIRED ON)
 
 if (CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER_ID MATCHES "GNU")
   target_compile_options(SFrameTests PUBLIC -Wall -pedantic -Wextra -Werror)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -5,21 +5,18 @@ project(SFrameTests
 )
 
 # Dependencies
+set(CMAKE_EXPORT_PACKAGE_REGISTRY ON)
+find_package(SFrame REQUIRED)
 find_package(doctest REQUIRED)
 find_package(OpenSSL 1.1 REQUIRED)
 
-# SFrame
-set(SFRAME_INCLUDE_DIR ${PROJECT_SOURCE_DIR}/../include)
-set(SFRAME_BINARY_DIR ${PROJECT_SOURCE_DIR}/../build)
-
 # Test Binary
-
 file(GLOB sources CONFIGURE_DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/*.cpp)
 
 add_executable(SFrameTests ${sources})
 target_include_directories(SFrameTests PRIVATE ${SFRAME_INCLUDE_DIR})
 target_link_directories(SFrameTests PRIVATE ${SFRAME_BINARY_DIR})
-target_link_libraries(SFrameTests doctest::doctest SFrame OpenSSL::Crypto)
+target_link_libraries(SFrameTests doctest::doctest SFrame::SFrame OpenSSL::Crypto)
 
 set_target_properties(SFrameTests PROPERTIES CXX_STANDARD 17)
 

--- a/test/Makefile
+++ b/test/Makefile
@@ -22,7 +22,7 @@ ${BUILD_DIR}: CMakeLists.txt
 	cmake ${GENERATOR} -B${BUILD_DIR} ${CMAKE_FLAGS} .
 
 clean:
-	cd ${BUILD_DIR} && ninja clean
+	cmake --build build --target clean
 
 cclean:
 	rm -rf ${BUILD_DIR}

--- a/test/Makefile
+++ b/test/Makefile
@@ -2,7 +2,6 @@
 # all the CMake commands and their arguments.
 
 # choose: Ninja, Unix Makefiles, Xcode, or leave blank for default
-GENERATOR=-G Ninja
 LIB_DIR=../build
 BUILD_DIR=build
 CLANG_FORMAT=clang-format
@@ -16,10 +15,10 @@ test: all
 	cd ${BUILD_DIR} && ctest
 
 tidy:
-	cmake ${GENERATOR} -B${BUILD_DIR} ${CMAKE_FLAGS} -DCLANG_TIDY=ON .
+	cmake -B${BUILD_DIR} -DCLANG_TIDY=ON .
 
 ${BUILD_DIR}: CMakeLists.txt
-	cmake ${GENERATOR} -B${BUILD_DIR} ${CMAKE_FLAGS} .
+	cmake -B${BUILD_DIR} .
 
 clean:
 	cmake --build build --target clean

--- a/test/Makefile
+++ b/test/Makefile
@@ -4,7 +4,6 @@
 # choose: Ninja, Unix Makefiles, Xcode, or leave blank for default
 LIB_DIR=../build
 BUILD_DIR=build
-CLANG_FORMAT=clang-format
 
 .PHONY: all tidy test clean cclean
 
@@ -13,9 +12,6 @@ all: ${BUILD_DIR} ${LIB_DIR}
 
 test: all
 	cd ${BUILD_DIR} && ctest
-
-tidy:
-	cmake -B${BUILD_DIR} -DCLANG_TIDY=ON .
 
 ${BUILD_DIR}: CMakeLists.txt
 	cmake -B${BUILD_DIR} .

--- a/test/Makefile
+++ b/test/Makefile
@@ -3,30 +3,26 @@
 
 # choose: Ninja, Unix Makefiles, Xcode, or leave blank for default
 GENERATOR=-G Ninja
+LIB_DIR=../build
 BUILD_DIR=build
 CLANG_FORMAT=clang-format
 
-.PHONY: all tidy test clean cclean format
+.PHONY: all tidy test clean cclean
 
-all: ${BUILD_DIR} format
+all: ${BUILD_DIR} ${LIB_DIR}
 	cmake --build ${BUILD_DIR}
 
 test: all
-	make -C test test
+	cd ${BUILD_DIR} && ctest
 
 tidy:
-	cmake ${GENERATOR} -B${BUILD_DIR} -DCLANG_TIDY=ON .
+	cmake ${GENERATOR} -B${BUILD_DIR} ${CMAKE_FLAGS} -DCLANG_TIDY=ON .
 
 ${BUILD_DIR}: CMakeLists.txt
-	cmake ${GENERATOR} -B${BUILD_DIR} .
+	cmake ${GENERATOR} -B${BUILD_DIR} ${CMAKE_FLAGS} .
 
 clean:
 	cd ${BUILD_DIR} && ninja clean
 
 cclean:
 	rm -rf ${BUILD_DIR}
-
-format:
-	${CLANG_FORMAT} -i src/*.cpp
-	${CLANG_FORMAT} -i include/sframe/*.h
-	${CLANG_FORMAT} -i test/*.cpp


### PR DESCRIPTION
Currently, the master CMakeLists.txt manages the building of the tests.  This PR flips that, so that the tests are effectively a separate project that relies on the library project as a dependency (and just happens to be in a subdirectory).