### PR TITLE
Use gsl::span

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,30 @@ endif()
 # External libraries
 find_package(OpenSSL 1.1 REQUIRED)
 
+# gsl-lite fetched from GitHub
+include( ExternalProject )
+find_package( Git REQUIRED )
+set( GSL_LITE_URL https://github.com/gsl-lite/gsl-lite.git )
+set_directory_properties( PROPERTIES EP_PREFIX ${CMAKE_BINARY_DIR}/third_party )
+
+ExternalProject_Add(
+    gsl-extern
+    GIT_REPOSITORY ${GSL_LITE_URL}
+    TIMEOUT 10
+    UPDATE_COMMAND ${GIT_EXECUTABLE} pull
+    CONFIGURE_COMMAND ""
+    BUILD_COMMAND ""
+    INSTALL_COMMAND ""
+    LOG_DOWNLOAD ON
+   )
+
+ExternalProject_Get_Property( gsl-extern SOURCE_DIR )
+set( GSL_LITE_INCLUDE_DIR ${SOURCE_DIR}/include CACHE INTERNAL "Include folder for gsl-lite" )
+
+add_library( gsl INTERFACE )
+add_dependencies(gsl gsl-extern)
+target_include_directories( gsl INTERFACE ${GSL_LITE_INCLUDE_DIR} )
+
 ###
 ### Library Config
 ###
@@ -46,12 +70,12 @@ file(GLOB_RECURSE LIB_HEADERS CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/inc
 file(GLOB_RECURSE LIB_SOURCES CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")
 
 add_library(${LIB_NAME} ${LIB_HEADERS} ${LIB_SOURCES})
+add_dependencies(${LIB_NAME} gsl)
+target_link_libraries(${LIB_NAME} PRIVATE gsl OpenSSL::Crypto)
 target_include_directories(${LIB_NAME}
   PUBLIC
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:include/${PROJECT_NAME}-${PROJECT_VERSION}>
-  PRIVATE
-    ${OPENSSL_INCLUDE_DIR}
 )
 
 ###

--- a/include/sframe/sframe.h
+++ b/include/sframe/sframe.h
@@ -35,7 +35,9 @@ public:
 
   void add_key(KeyID kid, const bytes& key);
 
-  output_bytes protect(KeyID key_id, output_bytes ciphertext, input_bytes plaintext);
+  output_bytes protect(KeyID key_id,
+                       output_bytes ciphertext,
+                       input_bytes plaintext);
   output_bytes unprotect(output_bytes plaintext, input_bytes ciphertext);
 
 private:

--- a/include/sframe/sframe.h
+++ b/include/sframe/sframe.h
@@ -4,6 +4,8 @@
 #include <map>
 #include <vector>
 
+#include <gsl/gsl-lite.hpp>
+
 namespace sframe {
 
 enum class CipherSuite : uint16_t

--- a/include/sframe/sframe.h
+++ b/include/sframe/sframe.h
@@ -4,7 +4,7 @@
 #include <map>
 #include <vector>
 
-#include <gsl/gsl-lite.hpp>
+#include <gsl/gsl>
 
 namespace sframe {
 
@@ -16,11 +16,14 @@ enum class CipherSuite : uint16_t
   AES_GCM_256_SHA512 = 4,
 };
 
-const size_t max_overhead = 12 + 16;
+constexpr size_t max_overhead = 17 + 16;
 
 using bytes = std::vector<uint8_t>;
+using input_bytes = gsl::span<const uint8_t>;
+using output_bytes = gsl::span<uint8_t>;
+
 std::ostream&
-operator<<(std::ostream& str, const bytes& data);
+operator<<(std::ostream& str, const input_bytes data);
 
 using KeyID = uint64_t;
 using Counter = uint64_t;
@@ -32,8 +35,8 @@ public:
 
   void add_key(KeyID kid, const bytes& key);
 
-  bytes protect(KeyID key_id, const bytes& plaintext);
-  bytes unprotect(const bytes& ciphertext);
+  output_bytes protect(KeyID key_id, output_bytes ciphertext, input_bytes plaintext);
+  output_bytes unprotect(output_bytes plaintext, input_bytes ciphertext);
 
 private:
   struct KeyState

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -7,8 +7,8 @@ find_package(doctest REQUIRED)
 file(GLOB TEST_SOURCES CONFIGURE_DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/*.cpp)
 
 add_executable(${TEST_APP_NAME} ${TEST_SOURCES})
-add_dependencies(${TEST_APP_NAME} ${LIB_NAME})
-target_link_libraries(${TEST_APP_NAME} ${LIB_NAME} doctest::doctest OpenSSL::Crypto)
+add_dependencies(${TEST_APP_NAME} ${LIB_NAME} gsl)
+target_link_libraries(${TEST_APP_NAME} ${LIB_NAME} gsl doctest::doctest OpenSSL::Crypto)
 
 # Enable CTest
 include(doctest)

--- a/test/sframe.cpp
+++ b/test/sframe.cpp
@@ -42,7 +42,9 @@ ciphersuite_name(CipherSuite suite)
 }
 
 template<typename T>
-bytes to_bytes(const T& range) {
+bytes
+to_bytes(const T& range)
+{
   return bytes(range.begin(), range.end());
 }
 

--- a/test/sframe.cpp
+++ b/test/sframe.cpp
@@ -41,6 +41,11 @@ ciphersuite_name(CipherSuite suite)
   }
 }
 
+template<typename T>
+bytes to_bytes(const T& range) {
+  return bytes(range.begin(), range.end());
+}
+
 TEST_CASE("SFrame Known-Answer")
 {
   struct KnownAnswerTest
@@ -97,6 +102,9 @@ TEST_CASE("SFrame Known-Answer")
       } },
   };
 
+  auto pt_out = bytes(plaintext.size());
+  auto ct_out = bytes(plaintext.size() + max_overhead);
+
   for (auto& pair : cases) {
     auto& suite = pair.first;
     auto& tc = pair.second;
@@ -106,31 +114,31 @@ TEST_CASE("SFrame Known-Answer")
     ctx.add_key(long_kid, tc.key);
 
     // KID=0x07, CTR=0, 1, 2
-    auto ct0 = ctx.protect(short_kid, plaintext);
-    auto ct1 = ctx.protect(short_kid, plaintext);
-    auto ct2 = ctx.protect(short_kid, plaintext);
+    auto ct0 = to_bytes(ctx.protect(short_kid, ct_out, plaintext));
+    auto ct1 = to_bytes(ctx.protect(short_kid, ct_out, plaintext));
+    auto ct2 = to_bytes(ctx.protect(short_kid, ct_out, plaintext));
 
     CHECK(ct0 == tc.short_kid_ctr0);
     CHECK(ct1 == tc.short_kid_ctr1);
     CHECK(ct2 == tc.short_kid_ctr2);
 
-    CHECK(plaintext == ctx.unprotect(ct0));
-    CHECK(plaintext == ctx.unprotect(ct1));
-    CHECK(plaintext == ctx.unprotect(ct2));
+    CHECK(plaintext == to_bytes(ctx.unprotect(pt_out, ct0)));
+    CHECK(plaintext == to_bytes(ctx.unprotect(pt_out, ct1)));
+    CHECK(plaintext == to_bytes(ctx.unprotect(pt_out, ct2)));
 
     // KID=0xffff, CTR=0
-    auto ctLS = ctx.protect(long_kid, plaintext);
+    auto ctLS = to_bytes(ctx.protect(long_kid, ct_out, plaintext));
     for (Counter ctr = 1; ctr < long_ctr; ctr++) {
-      ctx.protect(long_kid, plaintext);
+      ctx.protect(long_kid, ct_out, plaintext);
     }
-    auto ctLL = ctx.protect(long_kid, plaintext);
+    auto ctLL = to_bytes(ctx.protect(long_kid, ct_out, plaintext));
 
-    CHECK(ctLS == tc.long_kid_short_ctr);
-    CHECK(ctLL == tc.long_kid_long_ctr);
+    CHECK(to_bytes(ctLS) == tc.long_kid_short_ctr);
+    CHECK(to_bytes(ctLL) == tc.long_kid_long_ctr);
 
-    CHECK(plaintext == ctx.unprotect(ct0));
-    CHECK(plaintext == ctx.unprotect(ct1));
-    CHECK(plaintext == ctx.unprotect(ct2));
+    CHECK(plaintext == to_bytes(ctx.unprotect(pt_out, ct0)));
+    CHECK(plaintext == to_bytes(ctx.unprotect(pt_out, ct1)));
+    CHECK(plaintext == to_bytes(ctx.unprotect(pt_out, ct2)));
   }
 }
 
@@ -151,6 +159,9 @@ TEST_CASE("SFrame Round-Trip")
                "505152535455565758595a5b5c5d5e5f") },
   };
 
+  auto pt_out = bytes(plaintext.size());
+  auto ct_out = bytes(plaintext.size() + max_overhead);
+
   for (auto& pair : keys) {
     auto& suite = pair.first;
     auto& key = pair.second;
@@ -162,8 +173,8 @@ TEST_CASE("SFrame Round-Trip")
     recv.add_key(kid, key);
 
     for (int i = 0; i < rounds; i++) {
-      auto encrypted = send.protect(kid, plaintext);
-      auto decrypted = recv.unprotect(encrypted);
+      auto encrypted = to_bytes(send.protect(kid, ct_out, plaintext));
+      auto decrypted = to_bytes(recv.unprotect(pt_out, encrypted));
       CHECK(decrypted == plaintext);
     }
   }


### PR DESCRIPTION
C++20 will provide `std::span` as a more idiomatic and safe way of dealing with non-owned memory.  In the meantime we can use `gsl::span` via gsl-lite.