### PR TITLE
fix stack-use-after-scope of HAMC object

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,7 @@ project(sframe
 )
 
 option(CLANG_TIDY "Perform linting with clang-tidy" OFF)
+option(ADDRESS_SANITIZER "Enable address sanitizer" OFF)
 
 ###
 ### Global Config
@@ -18,6 +19,14 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER_ID MATCHES "GNU"
   add_compile_options(-Wall -pedantic -Wextra -Werror -Wmissing-declarations)
 elseif(MSVC)
   add_compile_options(/W4 /WX)
+endif()
+
+if (ADDRESS_SANITIZER)
+  set (CMAKE_C_FLAGS              "${CMAKE_C_FLAGS} -fsanitize=address")
+  set (CMAKE_CXX_FLAGS            "${CMAKE_CXX_FLAGS} -fsanitize=address")
+  set (CMAKE_EXE_LINKER_FLAGS     "${CMAKE_EXE_LINKER_FLAGS}    -fsanitize=address")
+  set (CMAKE_SHARED_LINKER_FLAGS  "${CMAKE_SHARED_LINKER_FLAGS} -fsanitize=address")
+  set (CMAKE_MODULE_LINKER_FLAGS  "${CMAKE_MODULE_LINKER_FLAGS} -fsanitize=address")
 endif()
 
 if(CLANG_TIDY)

--- a/src/crypto.cpp
+++ b/src/crypto.cpp
@@ -150,7 +150,9 @@ HMAC::digest()
 bytes
 hkdf_extract(CipherSuite suite, const bytes& salt, const bytes& ikm)
 {
-  auto mac = HMAC(suite, salt).write(ikm).digest();
+  auto hmac = HMAC(suite, salt);
+  hmac.write(ikm);
+  auto mac = hmac.digest();
   return bytes(mac.begin(), mac.end());
 }
 
@@ -171,7 +173,9 @@ hkdf_expand(CipherSuite suite,
 
   auto label = info;
   label.push_back(0x01);
-  auto mac = HMAC(suite, secret).write(label).digest();
+  auto hmac = HMAC(suite, secret);
+  hmac.write(label);
+  auto mac = hmac.digest();
   return bytes(mac.begin(), mac.begin() + size);
 }
 
@@ -241,7 +245,10 @@ seal_ctr(CipherSuite suite,
   ctr_crypt(suite, enc_key, nonce, inner_ct, pt);
 
   // Authenticate with truncated HMAC
-  auto mac = HMAC(suite, auth_key).write(aad).write(inner_ct).digest();
+  auto hmac = HMAC(suite, auth_key);
+  hmac.write(aad);
+  hmac.write(inner_ct);
+  auto mac = hmac.digest();
   auto tag = ct.subspan(pt.size(), tag_size);
   std::copy(mac.begin(), mac.begin() + tag_size, tag.begin());
 

--- a/src/crypto.h
+++ b/src/crypto.h
@@ -33,7 +33,7 @@ cipher_nonce_size(CipherSuite suite);
 struct HMAC
 {
   HMAC(CipherSuite suite, input_bytes key);
-  HMAC& write(input_bytes data);
+  void write(input_bytes data);
   input_bytes digest();
 
   scoped_hmac_ctx ctx;


### PR DESCRIPTION
HMAC::digest() returns a span referencing data inside
the HMAC object so the object needs to stay in scope
while the span is used.

Also add basic support for running with address sanitizer.

cmake -DADDRESS_SANITIZER=ON