### PR TITLE
Use typed errors

### DIFF
--- a/include/sframe/sframe.h
+++ b/include/sframe/sframe.h
@@ -8,6 +8,33 @@
 
 namespace sframe {
 
+struct openssl_error : std::runtime_error
+{
+  openssl_error();
+};
+
+struct unsupported_ciphersuite_error : std::runtime_error
+{
+  unsupported_ciphersuite_error();
+};
+
+struct authentication_error : std::runtime_error
+{
+  authentication_error();
+};
+
+struct buffer_too_small_error : std::runtime_error
+{
+  using parent = std::runtime_error;
+  using parent::parent;
+};
+
+struct invalid_parameter_error : std::runtime_error
+{
+  using parent = std::runtime_error;
+  using parent::parent;
+};
+
 enum class CipherSuite : uint16_t
 {
   AES_CM_128_HMAC_SHA256_4 = 1,

--- a/src/crypto.cpp
+++ b/src/crypto.cpp
@@ -9,12 +9,9 @@ namespace sframe {
 /// Convert between native identifiers / errors and OpenSSL ones
 ///
 
-static std::runtime_error
-openssl_error()
-{
-  auto code = ERR_get_error();
-  return std::runtime_error(ERR_error_string(code, nullptr));
-}
+openssl_error::openssl_error()
+  : std::runtime_error(ERR_error_string(ERR_get_error(), nullptr))
+{}
 
 static const EVP_MD*
 openssl_digest_type(CipherSuite suite)
@@ -29,7 +26,7 @@ openssl_digest_type(CipherSuite suite)
       return EVP_sha512();
 
     default:
-      throw std::runtime_error("Unsupported ciphersuite");
+      throw unsupported_ciphersuite_error();
   }
 }
 
@@ -48,7 +45,7 @@ openssl_cipher(CipherSuite suite)
       return EVP_aes_256_gcm();
 
     default:
-      throw std::runtime_error("Unsupported ciphersuite");
+      throw unsupported_ciphersuite_error();
   }
 }
 
@@ -67,7 +64,7 @@ openssl_tag_size(CipherSuite suite)
       return 16;
 
     default:
-      throw std::runtime_error("Unsupported ciphersuite");
+      throw unsupported_ciphersuite_error();
   }
 }
 
@@ -94,7 +91,7 @@ cipher_key_size(CipherSuite suite)
       return 32;
 
     default:
-      throw std::runtime_error("Unsupported ciphersuite");
+      throw unsupported_ciphersuite_error();
   }
 }
 
@@ -109,7 +106,7 @@ cipher_nonce_size(CipherSuite suite)
       return 12;
 
     default:
-      throw std::runtime_error("Unsupported ciphersuite");
+      throw unsupported_ciphersuite_error();
   }
 }
 
@@ -166,7 +163,7 @@ hkdf_expand(CipherSuite suite,
 {
   // Ensure that we need only one hash invocation
   if (size > cipher_digest_size(suite)) {
-    throw std::runtime_error("Size too big for hkdf_expand");
+    throw invalid_parameter_error("Size too big for hkdf_expand");
   }
 
   auto label = info;
@@ -189,7 +186,7 @@ ctr_crypt(CipherSuite suite,
           input_bytes in)
 {
   if (out.size() != in.size()) {
-    throw std::runtime_error("CTR size mismatch");
+    throw buffer_too_small_error("CTR size mismatch");
   }
 
   auto ctx = scoped_evp_ctx(EVP_CIPHER_CTX_new(), EVP_CIPHER_CTX_free);
@@ -229,7 +226,7 @@ seal_ctr(CipherSuite suite,
 {
   auto tag_size = openssl_tag_size(suite);
   if (ct.size() < pt.size() + tag_size) {
-    throw std::runtime_error("Ciphertext buffer too small");
+    throw buffer_too_small_error("Ciphertext buffer too small");
   }
 
   // Split the key into enc and auth subkeys
@@ -263,7 +260,7 @@ seal_aead(CipherSuite suite,
 {
   auto tag_size = openssl_tag_size(suite);
   if (ct.size() < pt.size() + tag_size) {
-    throw std::runtime_error("Ciphertext buffer too small");
+    throw buffer_too_small_error("Ciphertext buffer too small");
   }
 
   auto ctx = scoped_evp_ctx(EVP_CIPHER_CTX_new(), EVP_CIPHER_CTX_free);
@@ -327,7 +324,7 @@ seal(CipherSuite suite,
     }
   }
 
-  throw std::runtime_error("Unknown algorithm");
+  throw unsupported_ciphersuite_error();
 }
 
 static output_bytes
@@ -340,7 +337,7 @@ open_ctr(CipherSuite suite,
 {
   auto tag_size = openssl_tag_size(suite);
   if (ct.size() < tag_size) {
-    throw std::runtime_error("Ciphertext buffer too small");
+    throw buffer_too_small_error("Ciphertext buffer too small");
   }
 
   auto inner_ct_size = ct.size() - tag_size;
@@ -359,7 +356,7 @@ open_ctr(CipherSuite suite,
   hmac.write(inner_ct);
   auto mac = hmac.digest();
   if (CRYPTO_memcmp(mac.data(), tag.data(), tag.size()) != 0) {
-    throw std::runtime_error("AEAD authentication failure");
+    throw authentication_error();
   }
 
   // Decrypt with AES-CM
@@ -378,12 +375,12 @@ open_aead(CipherSuite suite,
 {
   auto tag_size = openssl_tag_size(suite);
   if (ct.size() < tag_size) {
-    throw std::runtime_error("Ciphertext buffer too small");
+    throw buffer_too_small_error("Ciphertext buffer too small");
   }
 
   auto inner_ct_size = ct.size() - tag_size;
   if (pt.size() < inner_ct_size) {
-    throw std::runtime_error("Plaintext buffer too small");
+    throw buffer_too_small_error("Plaintext buffer too small");
   }
 
   auto ctx = scoped_evp_ctx(EVP_CIPHER_CTX_new(), EVP_CIPHER_CTX_free);
@@ -421,7 +418,7 @@ open_aead(CipherSuite suite,
   // Providing nullptr as an argument is safe here because this
   // function never writes with GCM; it only verifies the tag
   if (1 != EVP_DecryptFinal(ctx.get(), nullptr, &out_size)) {
-    throw std::runtime_error("AEAD authentication failure");
+    throw authentication_error();
   }
 
   return pt.subspan(0, inner_ct_size);
@@ -447,7 +444,7 @@ open(CipherSuite suite,
     }
   }
 
-  throw std::runtime_error("Unknown algorithm");
+  throw unsupported_ciphersuite_error();
 }
 
 } // namespace sframe

--- a/src/header.cpp
+++ b/src/header.cpp
@@ -43,7 +43,7 @@ Header::size() const
 
   const auto ctr_size = uint_size(counter);
   if ((kid_size > 0x07) || (ctr_size > 0x07)) {
-    throw std::runtime_error("Header overflow");
+    throw buffer_too_small_error("Header overflow");
   }
 
   return 1 + kid_size + ctr_size;
@@ -53,7 +53,7 @@ std::tuple<Header, input_bytes>
 Header::decode(input_bytes buffer)
 {
   if (buffer.size() < Header::min_size) {
-    throw std::runtime_error("Ciphertext too small to decode header");
+    throw buffer_too_small_error("Ciphertext too small to decode header");
   }
 
   auto cfg = buffer[0];
@@ -64,7 +64,7 @@ Header::decode(input_bytes buffer)
   auto key_id = KeyID(kid_size);
   if (kid_long) {
     if (buffer.size() < 1 + kid_size) {
-      throw std::runtime_error("Ciphertext too small to decode KID");
+      throw buffer_too_small_error("Ciphertext too small to decode KID");
     }
 
     key_id = KeyID(decode_uint(buffer.subspan(1, kid_size)));
@@ -73,7 +73,7 @@ Header::decode(input_bytes buffer)
   }
 
   if (buffer.size() < 1 + kid_size + ctr_size) {
-    throw std::runtime_error("Ciphertext too small to decode CTR");
+    throw buffer_too_small_error("Ciphertext too small to decode CTR");
   }
   auto counter = Counter(decode_uint(buffer.subspan(1 + kid_size, ctr_size)));
 
@@ -85,7 +85,7 @@ size_t
 Header::encode(output_bytes buffer) const
 {
   if (buffer.size() < size()) {
-    throw std::runtime_error("Buffer too small to encode header");
+    throw buffer_too_small_error("Buffer too small to encode header");
   }
 
   auto kid_size = uint_size(key_id);

--- a/src/sframe.cpp
+++ b/src/sframe.cpp
@@ -22,6 +22,18 @@ operator<<(std::ostream& str, const input_bytes data)
 }
 
 ///
+/// Errors
+///
+
+unsupported_ciphersuite_error::unsupported_ciphersuite_error()
+  : std::runtime_error("Unsupported ciphersuite")
+{}
+
+authentication_error::authentication_error()
+  : std::runtime_error("AEAD authentication failure")
+{}
+
+///
 /// Context
 ///
 
@@ -139,7 +151,7 @@ Context::get_state(KeyID key_id)
 {
   auto it = state.find(key_id);
   if (it == state.end()) {
-    throw std::runtime_error("Unknown key");
+    throw invalid_parameter_error("Unknown key");
   }
 
   return it->second;
@@ -212,7 +224,7 @@ MLSContext::get_state(KeyID key_id)
 
   auto& epoch = epoch_cache.at(epoch_index);
   if (!epoch.has_value()) {
-    throw std::runtime_error("Unknown epoch");
+    throw invalid_parameter_error("Unknown epoch");
   }
 
   return epoch->get(suite, sender_id);


### PR DESCRIPTION
This PR introduces distinct error types derived from `std::runtime_error` to help applications distinguish various error cases.