### PR TITLE
Fix MSVC compiler warnings

### DIFF
--- a/include/sframe/sframe.h
+++ b/include/sframe/sframe.h
@@ -2,6 +2,7 @@
 
 #include <iosfwd>
 #include <map>
+#include <optional>
 #include <vector>
 
 #include <gsl/gsl>

--- a/src/crypto.cpp
+++ b/src/crypto.cpp
@@ -121,9 +121,8 @@ HMAC::HMAC(CipherSuite suite, input_bytes key)
   : ctx(HMAC_CTX_new(), HMAC_CTX_free)
 {
   auto type = openssl_digest_type(suite);
-  if (1 !=
-      HMAC_Init_ex(
-        ctx.get(), key.data(), static_cast<int>(key.size()), type, nullptr)) {
+  auto key_size = static_cast<int>(key.size());
+  if (1 != HMAC_Init_ex(ctx.get(), key.data(), key_size, type, nullptr)) {
     throw openssl_error();
   }
 }
@@ -301,10 +300,9 @@ seal_aead(CipherSuite suite,
 
   auto tag = ct.subspan(pt.size(), tag_size);
   auto tag_ptr = const_cast<void*>(static_cast<const void*>(tag.data()));
-  if (1 != EVP_CIPHER_CTX_ctrl(ctx.get(),
-                               EVP_CTRL_GCM_GET_TAG,
-                               static_cast<int>(tag.size()),
-                               tag_ptr)) {
+  auto tag_size = static_cast<int>(tag.size());
+  if (1 != EVP_CIPHER_CTX_ctrl(
+             ctx.get(), EVP_CTRL_GCM_GET_TAG, tag_size, tag_ptr)) {
     throw openssl_error();
   }
 
@@ -402,10 +400,9 @@ open_aead(CipherSuite suite,
 
   auto tag = ct.subspan(inner_ct_size, tag_size);
   auto tag_ptr = const_cast<void*>(static_cast<const void*>(tag.data()));
-  if (1 != EVP_CIPHER_CTX_ctrl(ctx.get(),
-                               EVP_CTRL_GCM_SET_TAG,
-                               static_cast<int>(tag.size()),
-                               tag_ptr)) {
+  auto tag_size = static_cast<int>(tag.size());
+  if (1 != EVP_CIPHER_CTX_ctrl(
+             ctx.get(), EVP_CTRL_GCM_SET_TAG, tag_size, tag_ptr)) {
     throw openssl_error();
   }
 

--- a/src/crypto.cpp
+++ b/src/crypto.cpp
@@ -300,9 +300,9 @@ seal_aead(CipherSuite suite,
 
   auto tag = ct.subspan(pt.size(), tag_size);
   auto tag_ptr = const_cast<void*>(static_cast<const void*>(tag.data()));
-  auto tag_size = static_cast<int>(tag.size());
+  auto tag_size_downcast = static_cast<int>(tag.size());
   if (1 != EVP_CIPHER_CTX_ctrl(
-             ctx.get(), EVP_CTRL_GCM_GET_TAG, tag_size, tag_ptr)) {
+             ctx.get(), EVP_CTRL_GCM_GET_TAG, tag_size_downcast, tag_ptr)) {
     throw openssl_error();
   }
 
@@ -400,9 +400,9 @@ open_aead(CipherSuite suite,
 
   auto tag = ct.subspan(inner_ct_size, tag_size);
   auto tag_ptr = const_cast<void*>(static_cast<const void*>(tag.data()));
-  auto tag_size = static_cast<int>(tag.size());
+  auto tag_size_downcast = static_cast<int>(tag.size());
   if (1 != EVP_CIPHER_CTX_ctrl(
-             ctx.get(), EVP_CTRL_GCM_SET_TAG, tag_size, tag_ptr)) {
+             ctx.get(), EVP_CTRL_GCM_SET_TAG, tag_size_downcast, tag_ptr)) {
     throw openssl_error();
   }
 

--- a/src/crypto.cpp
+++ b/src/crypto.cpp
@@ -121,7 +121,9 @@ HMAC::HMAC(CipherSuite suite, input_bytes key)
   : ctx(HMAC_CTX_new(), HMAC_CTX_free)
 {
   auto type = openssl_digest_type(suite);
-  if (1 != HMAC_Init_ex(ctx.get(), key.data(), key.size(), type, nullptr)) {
+  if (1 !=
+      HMAC_Init_ex(
+        ctx.get(), key.data(), static_cast<int>(key.size()), type, nullptr)) {
     throw openssl_error();
   }
 }
@@ -299,8 +301,10 @@ seal_aead(CipherSuite suite,
 
   auto tag = ct.subspan(pt.size(), tag_size);
   auto tag_ptr = const_cast<void*>(static_cast<const void*>(tag.data()));
-  if (1 != EVP_CIPHER_CTX_ctrl(
-             ctx.get(), EVP_CTRL_GCM_GET_TAG, tag.size(), tag_ptr)) {
+  if (1 != EVP_CIPHER_CTX_ctrl(ctx.get(),
+                               EVP_CTRL_GCM_GET_TAG,
+                               static_cast<int>(tag.size()),
+                               tag_ptr)) {
     throw openssl_error();
   }
 
@@ -398,8 +402,10 @@ open_aead(CipherSuite suite,
 
   auto tag = ct.subspan(inner_ct_size, tag_size);
   auto tag_ptr = const_cast<void*>(static_cast<const void*>(tag.data()));
-  if (1 != EVP_CIPHER_CTX_ctrl(
-             ctx.get(), EVP_CTRL_GCM_SET_TAG, tag.size(), tag_ptr)) {
+  if (1 != EVP_CIPHER_CTX_ctrl(ctx.get(),
+                               EVP_CTRL_GCM_SET_TAG,
+                               static_cast<int>(tag.size()),
+                               tag_ptr)) {
     throw openssl_error();
   }
 

--- a/src/header.cpp
+++ b/src/header.cpp
@@ -91,10 +91,10 @@ Header::encode(output_bytes buffer) const
   auto kid_size = uint_size(key_id);
   if (key_id <= 0x07) {
     kid_size = 0;
-    buffer[0] = key_id;
+    buffer[0] = static_cast<uint8_t>(key_id);
   } else {
     encode_uint(key_id, buffer.subspan(1, kid_size));
-    buffer[0] = 0x08 | kid_size;
+    buffer[0] = static_cast<uint8_t>(0x08 | kid_size);
   }
 
   auto ctr_size = uint_size(counter);

--- a/src/sframe.cpp
+++ b/src/sframe.cpp
@@ -152,8 +152,8 @@ Context::get_state(KeyID key_id)
 MLSContext::MLSContext(CipherSuite suite_in, size_t epoch_bits_in)
   : SFrame(suite_in)
   , epoch_bits(epoch_bits_in)
-  , epoch_mask(((size_t)1 << epoch_bits_in) - 1)
-  , epoch_cache((size_t)1 << epoch_bits_in, std::nullopt)
+  , epoch_mask((size_t(1) << epoch_bits_in) - 1)
+  , epoch_cache(size_t(1) << epoch_bits_in, std::nullopt)
 {}
 
 void

--- a/src/sframe.cpp
+++ b/src/sframe.cpp
@@ -152,8 +152,8 @@ Context::get_state(KeyID key_id)
 MLSContext::MLSContext(CipherSuite suite_in, size_t epoch_bits_in)
   : SFrame(suite_in)
   , epoch_bits(epoch_bits_in)
-  , epoch_mask((1 << epoch_bits_in) - 1)
-  , epoch_cache(1 << epoch_bits_in, std::nullopt)
+  , epoch_mask(((size_t)1 << epoch_bits_in) - 1)
+  , epoch_cache((size_t)1 << epoch_bits_in, std::nullopt)
 {}
 
 void
@@ -185,20 +185,20 @@ MLSContext::EpochKeys::EpochKeys(bytes sframe_epoch_secret_in)
 {}
 
 SFrame::KeyState&
-MLSContext::EpochKeys::get(CipherSuite suite, SenderID sender_id)
+MLSContext::EpochKeys::get(CipherSuite ciphersuite, SenderID sender_id)
 {
   auto it = sender_keys.find(sender_id);
   if (it != sender_keys.end()) {
     return it->second;
   }
 
-  auto hash_size = cipher_digest_size(suite);
+  auto hash_size = cipher_digest_size(ciphersuite);
   auto enc_sender_id = bytes(4);
   encode_uint(sender_id, enc_sender_id);
 
   auto sender_base_key =
-    hkdf_expand(suite, sframe_epoch_secret, enc_sender_id, hash_size);
-  auto key_state = KeyState::from_base_key(suite, sender_base_key);
+    hkdf_expand(ciphersuite, sframe_epoch_secret, enc_sender_id, hash_size);
+  auto key_state = KeyState::from_base_key(ciphersuite, sender_base_key);
   sender_keys.insert({ sender_id, std::move(key_state) });
 
   return sender_keys.at(sender_id);


### PR DESCRIPTION
Silences a few MSVC compilation issues due to warnings. 

- Missing `<optional>` include 
- `size_t` values explicitly downcast to `int`
- Bit shift warnings
- `suite` rename due to member variable shadowing