### PR TITLE
Add support for old CMake and C++11

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.5)
 
 project(sframe
   VERSION 0.1
@@ -13,7 +13,7 @@ option(ADDRESS_SANITIZER "Enable address sanitizer" OFF)
 ###
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 if (CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER_ID MATCHES "GNU")
   add_compile_options(-Wall -pedantic -Wextra -Werror -Wmissing-declarations)

--- a/include/sframe/sframe.h
+++ b/include/sframe/sframe.h
@@ -2,7 +2,7 @@
 
 #include <iosfwd>
 #include <map>
-#include <optional>
+#include <memory>
 #include <vector>
 
 #include <gsl/gsl>
@@ -128,7 +128,7 @@ private:
     KeyState& get(CipherSuite suite, SenderID sender_id);
   };
 
-  std::vector<std::optional<EpochKeys>> epoch_cache;
+  std::vector<std::unique_ptr<EpochKeys>> epoch_cache;
   KeyState& get_state(KeyID key_id) override;
 };
 


### PR DESCRIPTION
Primary changes:
* Lower the required CMake version in CMakeLists.txt
* Replace one usage of `std::optional<T>` with `std::unique_ptr<T>`
* Replace one destructuring assignment with manual destructuring