### PR TITLE
Don't build tests by default

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,7 +52,7 @@ jobs:
 
     - name: configure to use clang-tidy and sanitizers      
       run: |
-        cmake -B "${{ env.CMAKE_BUILD_DIR }}" -DCLANG_TIDY=ON -DSANITIZERS=ON -DCMAKE_BUILD_TYPE=Debug -DCMAKE_TOOLCHAIN_FILE="${{ matrix.vcpkg-cmake-file}}" .
+        cmake -B "${{ env.CMAKE_BUILD_DIR }}" -DCLANG_TIDY=ON -DTESTING=ON -DSANITIZERS=ON -DCMAKE_TOOLCHAIN_FILE="${{ matrix.vcpkg-cmake-file}}" .
 
     - name: build
       run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,7 @@ project(sframe
   LANGUAGES CXX
 )
 
+option(TESTING    "Build tests" OFF)
 option(CLANG_TIDY "Perform linting with clang-tidy" OFF)
 option(SANITIZERS "Enable sanitizers" OFF)
 
@@ -38,11 +39,6 @@ if(CLANG_TIDY)
     message(WARNING "clang-tidy requested, but not found")
   endif()
 endif()
-
-###
-### Enable testing
-###
-enable_testing()
 
 ###
 ### Dependencies
@@ -96,5 +92,7 @@ target_include_directories(${LIB_NAME}
 ###
 ### Tests
 ###
-add_subdirectory(test)
-
+if(TESTING)
+  enable_testing()
+  add_subdirectory(test)
+endif()

--- a/Makefile
+++ b/Makefile
@@ -16,10 +16,10 @@ all: ${BUILD_DIR}
 	cmake --build ${BUILD_DIR} --target sframe
 
 ${BUILD_DIR}: CMakeLists.txt test/CMakeLists.txt
-	cmake -B${BUILD_DIR} -DCMAKE_BUILD_TYPE=Debug .
+	cmake -B${BUILD_DIR} .
 
-tidy:
-	cmake -B${BUILD_DIR} -DCLANG_TIDY=ON -DCMAKE_BUILD_TYPE=Debug .
+dev: CMakeLists.txt test/CMakeLists.txt
+	cmake -B${BUILD_DIR} -DCLANG_TIDY=ON -DTESTING=ON -DSANITIZERS=ON .
 
 test: ${BUILD_DIR} test/*
 	cmake --build ${BUILD_DIR} --target sframe_test

--- a/README.md
+++ b/README.md
@@ -4,18 +4,8 @@
 This repository contains an implementation of [the draft SFrame
 standard](https://datatracker.ietf.org/doc/html/draft-omara-sframe) for
 end-to-end media encryption.  Since the spec is still in progress, the
-implementation here doesn't match exactly.  For example:
-
-* We do not derive key/salt from the master key.  The key is used directly, and
-  the nonce is formed directly from the counter, with no salt.
-
-* We use AES-GCM instead of the AES-CTR + HMAC construction in the
-  specification.
-
-* We include the SFrame header as AAD in the encryption
-
-Ideally, these differences will resolve as the specification and this
-implementaiton evolve together.
+implementation here might not match exactly.  iThese differences will resolve as
+the specification and this implementaiton evolve together.
 
 ## Building and Running Tests
 
@@ -23,11 +13,13 @@ A convenience Makefile is included to avoid the need to remember a bunch of
 CMake parameters.
 
 ```
-> make        # Builds the library
+> make        # Configures and builds the library 
+> make dev    # Configure a "developer" build with tests and checks
 > make test   # Builds and runs tests
 > make format # Runs clang-format over the source
 ```
 
 ## Prerequisites
 
-You need openssl 1.1 or greater installed, C++ compiler, make, and cmake
+You need openssl 1.1 or greater installed, C++ compiler, make, and cmake.  To
+run tests, you will need the doctest framework.


### PR DESCRIPTION
Currently, the default CMake configuration configures the build for tests as well as the library itself, including pulling in doctest as a dependency.  This PR puts test configuration/build behind a `TESTING` option for the CMake build, off by default.