### PR TITLE
Use OpenSSL's HKDF functions directly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ ${BUILD_DIR}: CMakeLists.txt test/CMakeLists.txt
 	cmake -B${BUILD_DIR} .
 
 dev: CMakeLists.txt test/CMakeLists.txt
-	cmake -B${BUILD_DIR} -DCLANG_TIDY=ON -DTESTING=ON -DSANITIZERS=ON .
+	cmake -B${BUILD_DIR} -DCMAKE_BUILD_TYPE=Debug -DCLANG_TIDY=ON -DTESTING=ON -DSANITIZERS=ON .
 
 test: ${BUILD_DIR} test/*
 	cmake --build ${BUILD_DIR} --target sframe_test

--- a/include/sframe/sframe.h
+++ b/include/sframe/sframe.h
@@ -5,7 +5,7 @@
 #include <memory>
 #include <vector>
 
-#include <gsl/gsl>
+#include <gsl/gsl-lite.hpp>
 
 namespace sframe {
 


### PR DESCRIPTION
This gives us a more direct and complete implementation of HKDF, as opposed to rolling our own.