### PR TITLE
Allow multiple contexts per MLS+SFrame sender

### DIFF
--- a/include/sframe/sframe.h
+++ b/include/sframe/sframe.h
@@ -5,7 +5,7 @@
 #include <memory>
 #include <vector>
 
-#include <gsl/gsl>
+#include <gsl/gsl-lite.hpp>
 
 namespace sframe {
 
@@ -103,17 +103,25 @@ class MLSContext : public SFrame
 {
 public:
   using EpochID = uint64_t;
-  using SenderID = uint32_t;
+  using SenderID = uint64_t;
+  using ContextID = uint64_t;
 
   MLSContext(CipherSuite suite_in, size_t epoch_bits_in);
 
   void add_epoch(EpochID epoch_id, const bytes& sframe_epoch_secret);
+  void add_epoch(EpochID epoch_id, const bytes& sframe_epoch_secret, size_t sender_bits);
   void purge_before(EpochID keeper);
 
   output_bytes protect(EpochID epoch_id,
                        SenderID sender_id,
                        output_bytes ciphertext,
                        input_bytes plaintext);
+  output_bytes protect(EpochID epoch_id,
+                       SenderID sender_id,
+                       ContextID context_id,
+                       output_bytes ciphertext,
+                       input_bytes plaintext);
+
   output_bytes unprotect(output_bytes plaintext, input_bytes ciphertext);
 
 private:
@@ -124,9 +132,10 @@ private:
   {
     const EpochID full_epoch;
     const bytes sframe_epoch_secret;
+    const size_t sender_bits;
     std::map<SenderID, KeyState> sender_keys;
 
-    EpochKeys(EpochID full_epoch_in, bytes sframe_epoch_secret_in);
+    EpochKeys(EpochID full_epoch_in, bytes sframe_epoch_secret_in, size_t sender_bits_in);
     KeyState& get(CipherSuite suite, SenderID sender_id);
   };
 

--- a/include/sframe/sframe.h
+++ b/include/sframe/sframe.h
@@ -109,7 +109,9 @@ public:
   MLSContext(CipherSuite suite_in, size_t epoch_bits_in);
 
   void add_epoch(EpochID epoch_id, const bytes& sframe_epoch_secret);
-  void add_epoch(EpochID epoch_id, const bytes& sframe_epoch_secret, size_t sender_bits);
+  void add_epoch(EpochID epoch_id,
+                 const bytes& sframe_epoch_secret,
+                 size_t sender_bits);
   void purge_before(EpochID keeper);
 
   output_bytes protect(EpochID epoch_id,
@@ -135,7 +137,9 @@ private:
     const size_t sender_bits;
     std::map<SenderID, KeyState> sender_keys;
 
-    EpochKeys(EpochID full_epoch_in, bytes sframe_epoch_secret_in, size_t sender_bits_in);
+    EpochKeys(EpochID full_epoch_in,
+              bytes sframe_epoch_secret_in,
+              size_t sender_bits_in);
     KeyState& get(CipherSuite suite, SenderID sender_id);
   };
 

--- a/src/sframe.cpp
+++ b/src/sframe.cpp
@@ -185,7 +185,9 @@ MLSContext::add_epoch(EpochID epoch_id, const bytes& sframe_epoch_secret)
 }
 
 void
-MLSContext::add_epoch(EpochID epoch_id, const bytes& sframe_epoch_secret, size_t sender_bits)
+MLSContext::add_epoch(EpochID epoch_id,
+                      const bytes& sframe_epoch_secret,
+                      size_t sender_bits)
 {
   auto epoch_index = epoch_id & epoch_mask;
   epoch_cache.at(epoch_index)
@@ -231,8 +233,9 @@ MLSContext::protect(EpochID epoch_id,
   auto sender_bits = epoch->sender_bits;
   if (sender_id >= (uint64_t(1) << sender_bits)) {
     throw invalid_parameter_error(
-      "Sender ID too large: " + std::to_string(sender_id) +
-      " > " + std::to_string(1 << sender_bits) + " sender_bits:" + std::to_string(sender_bits));
+      "Sender ID too large: " + std::to_string(sender_id) + " > " +
+      std::to_string(1 << sender_bits) +
+      " sender_bits:" + std::to_string(sender_bits));
   }
 
   auto context_part = uint64_t(context_id) << (epoch_bits + sender_bits);

--- a/src/sframe.cpp
+++ b/src/sframe.cpp
@@ -264,7 +264,7 @@ MLSContext::EpochKeys::get(CipherSuite ciphersuite, SenderID sender_id)
   }
 
   auto hash_size = cipher_digest_size(ciphersuite);
-  auto enc_sender_id = bytes(4);
+  auto enc_sender_id = bytes(8);
   encode_uint(sender_id, enc_sender_id);
 
   auto sender_base_key =

--- a/test/sframe.cpp
+++ b/test/sframe.cpp
@@ -312,13 +312,9 @@ TEST_CASE("MLS Known-Answer")
 
 TEST_CASE("MLS Round-Trip")
 {
-<<<<<<< HEAD
-  const auto epoch_bits = 4;
-=======
   ensure_fips_if_required();
 
   const auto epoch_bits = 2;
->>>>>>> master
   const auto test_epochs = 1 << (epoch_bits + 1);
   const auto epoch_rounds = 10;
   const auto plaintext = from_hex("00010203");
@@ -363,6 +359,8 @@ TEST_CASE("MLS Round-Trip")
 
 TEST_CASE("MLS Known-Answer with Context")
 {
+  ensure_fips_if_required();
+
   struct KnownAnswerTest
   {
     using ContextCases = std::vector<bytes>;
@@ -645,6 +643,8 @@ TEST_CASE("MLS Known-Answer with Context")
 
 TEST_CASE("MLS Round-Trip with context")
 {
+  ensure_fips_if_required();
+
   const auto epoch_bits = 4;
   const auto test_epochs = 1 << (epoch_bits + 1);
   const auto epoch_rounds = 10;

--- a/test/sframe.cpp
+++ b/test/sframe.cpp
@@ -192,78 +192,78 @@ TEST_CASE("MLS Known-Answer")
     0xaaa,
   };
   const std::map<CipherSuite, KnownAnswerTest> cases{
-{ CipherSuite::AES_CM_128_HMAC_SHA256_4,
-  { {
-    {
-      from_hex("09a000a099f9cfcebe0016"),
-      from_hex("0a0aa000102ea6af868bda78"),
-      from_hex("0aaaa0009c0aa3c3dc43d075"),
-    },
-    {
-      from_hex("09af008414bb5861dec7d0"),
-      from_hex("0a0aaf004486695c578d1d7b"),
-      from_hex("0aaaaf00da9a202a28d52f29"),
-    },
-    {
-      from_hex("09a0008f7b4591e6f1bc5b"),
-      from_hex("0a0aa00039743979f1e9e9f5"),
-      from_hex("0aaaa000658794f1db8a4553"),
-    },
-  } } },
-{ CipherSuite::AES_CM_128_HMAC_SHA256_8,
-  { {
-    {
-      from_hex("09a000a099f9cfcebe0016ec6d4089"),
-      from_hex("0a0aa000102ea6af868bda7839a896e4"),
-      from_hex("0aaaa0009c0aa3c3dc43d07567ed7c50"),
-    },
-    {
-      from_hex("09af008414bb5861dec7d0e1e2bc71"),
-      from_hex("0a0aaf004486695c578d1d7b90e9b557"),
-      from_hex("0aaaaf00da9a202a28d52f29f4bf0ddf"),
-    },
-    {
-      from_hex("09a0008f7b4591e6f1bc5bd3568ba2"),
-      from_hex("0a0aa00039743979f1e9e9f57e4a5553"),
-      from_hex("0aaaa000658794f1db8a45534bfde555"),
-    },
-  } } },
-{ CipherSuite::AES_GCM_128_SHA256,
-  { {
-    {
-      from_hex("09a000f32e41cdb15b8c9c3bd57e4ed008f056fa263df3"),
-      from_hex("0a0aa000ad96fdf39faf8711d53279f8549ad4fb23f1f8aa"),
-      from_hex("0aaaa000c79771b0d97bf9035b920fb1bb565c4025cf8a47"),
-    },
-    {
-      from_hex("09af00feb0c2b242d3c8a9aec464fc92f55c9539d5caa8"),
-      from_hex("0a0aaf00c0afce4867ee782c45de14a1990ea5576f41fa52"),
-      from_hex("0aaaaf00d034912de869721e8ea2e5724d3eb69f4b7c7e6a"),
-    },
-    {
-      from_hex("09a00003fa0e4e4c36bc0aed031c56b1db488c525831b3"),
-      from_hex("0a0aa000184a009fdfa7d0ee2c36a9e9ee1d21663b4dcde1"),
-      from_hex("0aaaa0008f2e842d16d4ec69b23623b7bd9838e4f906bab1"),
-    },
-  } } },
-{ CipherSuite::AES_GCM_256_SHA512,
-  { {
-    {
-      from_hex("09a0007878e804d643a86c6ec1711ee2b6a9e6aa4d9be8"),
-      from_hex("0a0aa00083f5083c175e74c484d837e35d6e359ef5dfc66a"),
-      from_hex("0aaaa0000144a05a1c3c75691b5597d01d1517d5ebc92460"),
-    },
-    {
-      from_hex("09af002a2be564b2a788abd838f01cfcec315563bdf708"),
-      from_hex("0a0aaf00ca411f242081522129078b6c5239f5e8baf10d67"),
-      from_hex("0aaaaf0011a1a4ea5a7796589931acc62c3a6ccf5008e3cc"),
-    },
-    {
-      from_hex("09a0003f5d9b66df64c7cb3cce99952028990a3869d3a8"),
-      from_hex("0a0aa0000b8a680c5bfc4efb8fb68041b5f63441e9aaaa85"),
-      from_hex("0aaaa00061c7c6a5b2882f037aea330533e0381d1f25e074"),
-    },
-  } } },
+    { CipherSuite::AES_CM_128_HMAC_SHA256_4,
+      { {
+        {
+          from_hex("09a000a099f9cfcebe0016"),
+          from_hex("0a0aa000102ea6af868bda78"),
+          from_hex("0aaaa0009c0aa3c3dc43d075"),
+        },
+        {
+          from_hex("09af008414bb5861dec7d0"),
+          from_hex("0a0aaf004486695c578d1d7b"),
+          from_hex("0aaaaf00da9a202a28d52f29"),
+        },
+        {
+          from_hex("09a0008f7b4591e6f1bc5b"),
+          from_hex("0a0aa00039743979f1e9e9f5"),
+          from_hex("0aaaa000658794f1db8a4553"),
+        },
+      } } },
+    { CipherSuite::AES_CM_128_HMAC_SHA256_8,
+      { {
+        {
+          from_hex("09a000a099f9cfcebe0016ec6d4089"),
+          from_hex("0a0aa000102ea6af868bda7839a896e4"),
+          from_hex("0aaaa0009c0aa3c3dc43d07567ed7c50"),
+        },
+        {
+          from_hex("09af008414bb5861dec7d0e1e2bc71"),
+          from_hex("0a0aaf004486695c578d1d7b90e9b557"),
+          from_hex("0aaaaf00da9a202a28d52f29f4bf0ddf"),
+        },
+        {
+          from_hex("09a0008f7b4591e6f1bc5bd3568ba2"),
+          from_hex("0a0aa00039743979f1e9e9f57e4a5553"),
+          from_hex("0aaaa000658794f1db8a45534bfde555"),
+        },
+      } } },
+    { CipherSuite::AES_GCM_128_SHA256,
+      { {
+        {
+          from_hex("09a000f32e41cdb15b8c9c3bd57e4ed008f056fa263df3"),
+          from_hex("0a0aa000ad96fdf39faf8711d53279f8549ad4fb23f1f8aa"),
+          from_hex("0aaaa000c79771b0d97bf9035b920fb1bb565c4025cf8a47"),
+        },
+        {
+          from_hex("09af00feb0c2b242d3c8a9aec464fc92f55c9539d5caa8"),
+          from_hex("0a0aaf00c0afce4867ee782c45de14a1990ea5576f41fa52"),
+          from_hex("0aaaaf00d034912de869721e8ea2e5724d3eb69f4b7c7e6a"),
+        },
+        {
+          from_hex("09a00003fa0e4e4c36bc0aed031c56b1db488c525831b3"),
+          from_hex("0a0aa000184a009fdfa7d0ee2c36a9e9ee1d21663b4dcde1"),
+          from_hex("0aaaa0008f2e842d16d4ec69b23623b7bd9838e4f906bab1"),
+        },
+      } } },
+    { CipherSuite::AES_GCM_256_SHA512,
+      { {
+        {
+          from_hex("09a0007878e804d643a86c6ec1711ee2b6a9e6aa4d9be8"),
+          from_hex("0a0aa00083f5083c175e74c484d837e35d6e359ef5dfc66a"),
+          from_hex("0aaaa0000144a05a1c3c75691b5597d01d1517d5ebc92460"),
+        },
+        {
+          from_hex("09af002a2be564b2a788abd838f01cfcec315563bdf708"),
+          from_hex("0a0aaf00ca411f242081522129078b6c5239f5e8baf10d67"),
+          from_hex("0aaaaf0011a1a4ea5a7796589931acc62c3a6ccf5008e3cc"),
+        },
+        {
+          from_hex("09a0003f5d9b66df64c7cb3cce99952028990a3869d3a8"),
+          from_hex("0a0aa0000b8a680c5bfc4efb8fb68041b5f63441e9aaaa85"),
+          from_hex("0aaaa00061c7c6a5b2882f037aea330533e0381d1f25e074"),
+        },
+      } } },
   };
 
   auto pt_out = bytes(plaintext.size());
@@ -349,7 +349,7 @@ TEST_CASE("MLS Known-Answer with Context")
 
   const auto plaintext = from_hex("00010203");
   const auto epoch_bits = 4;
-  //const auto sender_bits = 12;
+  // const auto sender_bits = 12;
   const auto epoch_ids = std::vector<MLSContext::EpochID>{
     0x00,
     0x0f,
@@ -372,222 +372,222 @@ TEST_CASE("MLS Known-Answer with Context")
   };
   const auto sender_bits = 12;
   const std::map<CipherSuite, KnownAnswerTest> cases{
-{ CipherSuite::AES_CM_128_HMAC_SHA256_4,
-  { {
-    {
-      {
-        from_hex("0b0b00a000e78b66f2396ad3fb"),
-        from_hex("0bbb00a000627f7a610c7d5114"),
-        from_hex("0c0bbb00a000010247612644e928"),
-      },
-      {
-        from_hex("0b0b0aa000065aacf40d149781"),
-        from_hex("0bbb0aa0003db4ff6316a3b4aa"),
-        from_hex("0c0bbb0aa000804e43f1e3b30c01"),
-      },
-      {
-        from_hex("0b0baaa0008ee32c082a6baced"),
-        from_hex("0bbbaaa000d158bf21f2be0aff"),
-        from_hex("0c0bbbaaa000ddb84e167700afcb"),
-      },
-    },
-    {
-      {
-        from_hex("0b0b00af00645a02cbd4dd5469"),
-        from_hex("0bbb00af00436630a155d66c9e"),
-        from_hex("0c0bbb00af000160419ebc8f5181"),
-      },
-      {
-        from_hex("0b0b0aaf009c1c9c9a6103a004"),
-        from_hex("0bbb0aaf003f0045b076151853"),
-        from_hex("0c0bbb0aaf00e638bf4dbafe35dc"),
-      },
-      {
-        from_hex("0b0baaaf002c21652122601e05"),
-        from_hex("0bbbaaaf001a40ca810397ca64"),
-        from_hex("0c0bbbaaaf00cbdcb9e4e401ee56"),
-      },
-    },
-    {
-      {
-        from_hex("0b0b00a000dadd1533c0418d7a"),
-        from_hex("0bbb00a000144ac3cfd5e4a563"),
-        from_hex("0c0bbb00a000b753901426810fcd"),
-      },
-      {
-        from_hex("0b0b0aa00006be6cd4471e3028"),
-        from_hex("0bbb0aa0008cea2fb844ed6440"),
-        from_hex("0c0bbb0aa000ad1376f533ebf44a"),
-      },
-      {
-        from_hex("0b0baaa000a20b1f3ed8499f8a"),
-        from_hex("0bbbaaa0006f311c5a7aaf0289"),
-        from_hex("0c0bbbaaa000ede89b44263ee250"),
-      },
-    },
-  } } },
-{ CipherSuite::AES_CM_128_HMAC_SHA256_8,
-  { {
-    {
-      {
-        from_hex("0b0b00a000e78b66f2396ad3fbb4a56007"),
-        from_hex("0bbb00a000627f7a610c7d51149811b320"),
-        from_hex("0c0bbb00a000010247612644e9287540ce73"),
-      },
-      {
-        from_hex("0b0b0aa000065aacf40d14978172ebf918"),
-        from_hex("0bbb0aa0003db4ff6316a3b4aadd53d398"),
-        from_hex("0c0bbb0aa000804e43f1e3b30c0197cfd76b"),
-      },
-      {
-        from_hex("0b0baaa0008ee32c082a6baced795e34b5"),
-        from_hex("0bbbaaa000d158bf21f2be0affa7f4a66d"),
-        from_hex("0c0bbbaaa000ddb84e167700afcbc8d2fe11"),
-      },
-    },
-    {
-      {
-        from_hex("0b0b00af00645a02cbd4dd546959a200ef"),
-        from_hex("0bbb00af00436630a155d66c9e16890d09"),
-        from_hex("0c0bbb00af000160419ebc8f51814fb3271a"),
-      },
-      {
-        from_hex("0b0b0aaf009c1c9c9a6103a004cab06cd0"),
-        from_hex("0bbb0aaf003f0045b07615185317303eb9"),
-        from_hex("0c0bbb0aaf00e638bf4dbafe35dc1853cc73"),
-      },
-      {
-        from_hex("0b0baaaf002c21652122601e056a27bc1d"),
-        from_hex("0bbbaaaf001a40ca810397ca646e2b08c3"),
-        from_hex("0c0bbbaaaf00cbdcb9e4e401ee566e91e386"),
-      },
-    },
-    {
-      {
-        from_hex("0b0b00a000dadd1533c0418d7ab42e193b"),
-        from_hex("0bbb00a000144ac3cfd5e4a563b8766bad"),
-        from_hex("0c0bbb00a000b753901426810fcdd91261a2"),
-      },
-      {
-        from_hex("0b0b0aa00006be6cd4471e30285c6e51df"),
-        from_hex("0bbb0aa0008cea2fb844ed64406dc495b6"),
-        from_hex("0c0bbb0aa000ad1376f533ebf44a3f778c81"),
-      },
-      {
-        from_hex("0b0baaa000a20b1f3ed8499f8a740a02a5"),
-        from_hex("0bbbaaa0006f311c5a7aaf02895ea699ed"),
-        from_hex("0c0bbbaaa000ede89b44263ee25013fc615d"),
-      },
-    },
-  } } },
-{ CipherSuite::AES_GCM_128_SHA256,
-  { {
-    {
-      {
-        from_hex("0b0b00a0006ecb201768cf6a0f14bbee09ad490c5a4e215650"),
-        from_hex("0bbb00a000bc4944c23dd62883911c247c4d42fb9cd1a60883"),
-        from_hex("0c0bbb00a000ea232bd73f103aebef947a487de72cbf4fae7add"),
-      },
-      {
-        from_hex("0b0b0aa000d0ead9e0b2bb2e52f82c1e377c27a49115694cc5"),
-        from_hex("0bbb0aa000fc894af5b173474384dc9b08d65875a85eeb42fa"),
-        from_hex("0c0bbb0aa0005df598693c6f1e5d567869302ad52064aba28157"),
-      },
-      {
-        from_hex("0b0baaa000051a97e25e94ab650b41890a0faa3747164ee2c0"),
-        from_hex("0bbbaaa000be93b0c301782fc4b7abf0a66b36120138fc86b9"),
-        from_hex("0c0bbbaaa0000e10273c8829af3eed30ad753763662e436a565d"),
-      },
-    },
-    {
-      {
-        from_hex("0b0b00af0034f26ddfee46ec7844f3d99e2895f1ba4325c74d"),
-        from_hex("0bbb00af00df339bf635ca2ae17d2f07b05e8edffd04518ae7"),
-        from_hex("0c0bbb00af000f3f4f26bb98f7a57870e376ddddf0da8ad9c6ae"),
-      },
-      {
-        from_hex("0b0b0aaf00d89a7e4ec825a3842f28c3ea40c8049f0cfe2084"),
-        from_hex("0bbb0aaf002278d74c851303f0e57553dc3e1933c3459a8487"),
-        from_hex("0c0bbb0aaf0076bccc828a1178dd36400b59a72d330e79e2bcc6"),
-      },
-      {
-        from_hex("0b0baaaf001f07a6d0f61dc787b82ca0a13b38093910df4eff"),
-        from_hex("0bbbaaaf00b69d6ada3cf060f7b010bb9b00fba19326e4d749"),
-        from_hex("0c0bbbaaaf00fd3231ba3a9a5db1e87a01d5ce4cd74f742ae46c"),
-      },
-    },
-    {
-      {
-        from_hex("0b0b00a000a054bb91c3097de21b58fea1fc1ccbc88570ebe5"),
-        from_hex("0bbb00a000e1d4a1511cf16bb6c222672a91d26ab33505c356"),
-        from_hex("0c0bbb00a0001865b9043654d287c8f3de32cc7cc6ad1bdfcfa9"),
-      },
-      {
-        from_hex("0b0b0aa0005fad155349c32ddd6dca93ac6a60c0c9b9533eb8"),
-        from_hex("0bbb0aa0003753e39c068bbfebe74ea6e2bb5234d90a5e7d6c"),
-        from_hex("0c0bbb0aa000ae9ca700d753cafc556525a5348bb4ad4ece56b9"),
-      },
-      {
-        from_hex("0b0baaa000e025c92b32b421efe6d6e1b9a04949498acaa9be"),
-        from_hex("0bbbaaa000d079005f5e967a5408b29de179a69db552f41843"),
-        from_hex("0c0bbbaaa000258742303cfbbcbf26ab10b490e866729242779b"),
-      },
-    },
-  } } },
-{ CipherSuite::AES_GCM_256_SHA512,
-  { {
-    {
-      {
-        from_hex("0b0b00a0008aa688a274acba1d92314a0f98794e1e50191392"),
-        from_hex("0bbb00a0005437ed5f1545ce989de0eb38f02f1ed06c74bcbe"),
-        from_hex("0c0bbb00a000439084e68b408b2430e9077739d9d0d53129188e"),
-      },
-      {
-        from_hex("0b0b0aa000af72f544b51c937d217ab488ed44db7c18b5fe16"),
-        from_hex("0bbb0aa00046c7750b1951594d8a12d76e4366b248d4422793"),
-        from_hex("0c0bbb0aa0002c5825a674df250f82b7b51dd01583689664db7c"),
-      },
-      {
-        from_hex("0b0baaa0008036596f12dcc552d0f03a794430d629439a205d"),
-        from_hex("0bbbaaa0009237f7cb947e9aedb97b0bf69557604c2c3356f5"),
-        from_hex("0c0bbbaaa000de9955378ee32a3aef148cd7ce05b93ee2508a74"),
-      },
-    },
-    {
-      {
-        from_hex("0b0b00af001c3d824df4c26e2d76d65f40840491fb577e7d26"),
-        from_hex("0bbb00af001e14b7f4ddc1b8fe5c29d279c7f35f46652b6265"),
-        from_hex("0c0bbb00af00d638340784a28863256a470667cb8521dd682f2d"),
-      },
-      {
-        from_hex("0b0b0aaf00f5ace84a9ac311216588637d012519d42461a698"),
-        from_hex("0bbb0aaf006f2d1fc9a688382e5b85b01d9f49563a0aa80d29"),
-        from_hex("0c0bbb0aaf00d8a865e3655d0a322106d35c3375ac3837a852c0"),
-      },
-      {
-        from_hex("0b0baaaf00a9b54ca17d87a0f4a64260fdb374ff60331a06c4"),
-        from_hex("0bbbaaaf00450e533cc76f31ffcd7080c2ec3d3e6ace9e9638"),
-        from_hex("0c0bbbaaaf0048a8028b1a28719158ab19c6fd1a0bf2e532f26b"),
-      },
-    },
-    {
-      {
-        from_hex("0b0b00a00015df4f7a226bd82e403c95eb0473c3b499b91c88"),
-        from_hex("0bbb00a00052e7cd8bb8cb68fde112740b154fd7ac63dfe45d"),
-        from_hex("0c0bbb00a00065539ae6be900e527bed4df63f9d5a28f0308659"),
-      },
-      {
-        from_hex("0b0b0aa0003617ffb2846dff0d01f73cb768fe332fb25187da"),
-        from_hex("0bbb0aa0006f6f9695211ec704a8374eea34768a29d28015b1"),
-        from_hex("0c0bbb0aa000dd52ace0a6cec57446268a52e8b0ae9f88c541d6"),
-      },
-      {
-        from_hex("0b0baaa000e37e4c8e7805ed3ec6d26f828825855c5f7b1be5"),
-        from_hex("0bbbaaa00028b3993f0ff97d32547dc88b1479ab6f5e7626c6"),
-        from_hex("0c0bbbaaa0001e93ae8c8daa541697b206ccff31ff12050ac035"),
-      },
-    },
-  } } },
+    { CipherSuite::AES_CM_128_HMAC_SHA256_4,
+      { {
+        {
+          {
+            from_hex("0b0b00a000e78b66f2396ad3fb"),
+            from_hex("0bbb00a000627f7a610c7d5114"),
+            from_hex("0c0bbb00a000010247612644e928"),
+          },
+          {
+            from_hex("0b0b0aa000065aacf40d149781"),
+            from_hex("0bbb0aa0003db4ff6316a3b4aa"),
+            from_hex("0c0bbb0aa000804e43f1e3b30c01"),
+          },
+          {
+            from_hex("0b0baaa0008ee32c082a6baced"),
+            from_hex("0bbbaaa000d158bf21f2be0aff"),
+            from_hex("0c0bbbaaa000ddb84e167700afcb"),
+          },
+        },
+        {
+          {
+            from_hex("0b0b00af00645a02cbd4dd5469"),
+            from_hex("0bbb00af00436630a155d66c9e"),
+            from_hex("0c0bbb00af000160419ebc8f5181"),
+          },
+          {
+            from_hex("0b0b0aaf009c1c9c9a6103a004"),
+            from_hex("0bbb0aaf003f0045b076151853"),
+            from_hex("0c0bbb0aaf00e638bf4dbafe35dc"),
+          },
+          {
+            from_hex("0b0baaaf002c21652122601e05"),
+            from_hex("0bbbaaaf001a40ca810397ca64"),
+            from_hex("0c0bbbaaaf00cbdcb9e4e401ee56"),
+          },
+        },
+        {
+          {
+            from_hex("0b0b00a000dadd1533c0418d7a"),
+            from_hex("0bbb00a000144ac3cfd5e4a563"),
+            from_hex("0c0bbb00a000b753901426810fcd"),
+          },
+          {
+            from_hex("0b0b0aa00006be6cd4471e3028"),
+            from_hex("0bbb0aa0008cea2fb844ed6440"),
+            from_hex("0c0bbb0aa000ad1376f533ebf44a"),
+          },
+          {
+            from_hex("0b0baaa000a20b1f3ed8499f8a"),
+            from_hex("0bbbaaa0006f311c5a7aaf0289"),
+            from_hex("0c0bbbaaa000ede89b44263ee250"),
+          },
+        },
+      } } },
+    { CipherSuite::AES_CM_128_HMAC_SHA256_8,
+      { {
+        {
+          {
+            from_hex("0b0b00a000e78b66f2396ad3fbb4a56007"),
+            from_hex("0bbb00a000627f7a610c7d51149811b320"),
+            from_hex("0c0bbb00a000010247612644e9287540ce73"),
+          },
+          {
+            from_hex("0b0b0aa000065aacf40d14978172ebf918"),
+            from_hex("0bbb0aa0003db4ff6316a3b4aadd53d398"),
+            from_hex("0c0bbb0aa000804e43f1e3b30c0197cfd76b"),
+          },
+          {
+            from_hex("0b0baaa0008ee32c082a6baced795e34b5"),
+            from_hex("0bbbaaa000d158bf21f2be0affa7f4a66d"),
+            from_hex("0c0bbbaaa000ddb84e167700afcbc8d2fe11"),
+          },
+        },
+        {
+          {
+            from_hex("0b0b00af00645a02cbd4dd546959a200ef"),
+            from_hex("0bbb00af00436630a155d66c9e16890d09"),
+            from_hex("0c0bbb00af000160419ebc8f51814fb3271a"),
+          },
+          {
+            from_hex("0b0b0aaf009c1c9c9a6103a004cab06cd0"),
+            from_hex("0bbb0aaf003f0045b07615185317303eb9"),
+            from_hex("0c0bbb0aaf00e638bf4dbafe35dc1853cc73"),
+          },
+          {
+            from_hex("0b0baaaf002c21652122601e056a27bc1d"),
+            from_hex("0bbbaaaf001a40ca810397ca646e2b08c3"),
+            from_hex("0c0bbbaaaf00cbdcb9e4e401ee566e91e386"),
+          },
+        },
+        {
+          {
+            from_hex("0b0b00a000dadd1533c0418d7ab42e193b"),
+            from_hex("0bbb00a000144ac3cfd5e4a563b8766bad"),
+            from_hex("0c0bbb00a000b753901426810fcdd91261a2"),
+          },
+          {
+            from_hex("0b0b0aa00006be6cd4471e30285c6e51df"),
+            from_hex("0bbb0aa0008cea2fb844ed64406dc495b6"),
+            from_hex("0c0bbb0aa000ad1376f533ebf44a3f778c81"),
+          },
+          {
+            from_hex("0b0baaa000a20b1f3ed8499f8a740a02a5"),
+            from_hex("0bbbaaa0006f311c5a7aaf02895ea699ed"),
+            from_hex("0c0bbbaaa000ede89b44263ee25013fc615d"),
+          },
+        },
+      } } },
+    { CipherSuite::AES_GCM_128_SHA256,
+      { {
+        {
+          {
+            from_hex("0b0b00a0006ecb201768cf6a0f14bbee09ad490c5a4e215650"),
+            from_hex("0bbb00a000bc4944c23dd62883911c247c4d42fb9cd1a60883"),
+            from_hex("0c0bbb00a000ea232bd73f103aebef947a487de72cbf4fae7add"),
+          },
+          {
+            from_hex("0b0b0aa000d0ead9e0b2bb2e52f82c1e377c27a49115694cc5"),
+            from_hex("0bbb0aa000fc894af5b173474384dc9b08d65875a85eeb42fa"),
+            from_hex("0c0bbb0aa0005df598693c6f1e5d567869302ad52064aba28157"),
+          },
+          {
+            from_hex("0b0baaa000051a97e25e94ab650b41890a0faa3747164ee2c0"),
+            from_hex("0bbbaaa000be93b0c301782fc4b7abf0a66b36120138fc86b9"),
+            from_hex("0c0bbbaaa0000e10273c8829af3eed30ad753763662e436a565d"),
+          },
+        },
+        {
+          {
+            from_hex("0b0b00af0034f26ddfee46ec7844f3d99e2895f1ba4325c74d"),
+            from_hex("0bbb00af00df339bf635ca2ae17d2f07b05e8edffd04518ae7"),
+            from_hex("0c0bbb00af000f3f4f26bb98f7a57870e376ddddf0da8ad9c6ae"),
+          },
+          {
+            from_hex("0b0b0aaf00d89a7e4ec825a3842f28c3ea40c8049f0cfe2084"),
+            from_hex("0bbb0aaf002278d74c851303f0e57553dc3e1933c3459a8487"),
+            from_hex("0c0bbb0aaf0076bccc828a1178dd36400b59a72d330e79e2bcc6"),
+          },
+          {
+            from_hex("0b0baaaf001f07a6d0f61dc787b82ca0a13b38093910df4eff"),
+            from_hex("0bbbaaaf00b69d6ada3cf060f7b010bb9b00fba19326e4d749"),
+            from_hex("0c0bbbaaaf00fd3231ba3a9a5db1e87a01d5ce4cd74f742ae46c"),
+          },
+        },
+        {
+          {
+            from_hex("0b0b00a000a054bb91c3097de21b58fea1fc1ccbc88570ebe5"),
+            from_hex("0bbb00a000e1d4a1511cf16bb6c222672a91d26ab33505c356"),
+            from_hex("0c0bbb00a0001865b9043654d287c8f3de32cc7cc6ad1bdfcfa9"),
+          },
+          {
+            from_hex("0b0b0aa0005fad155349c32ddd6dca93ac6a60c0c9b9533eb8"),
+            from_hex("0bbb0aa0003753e39c068bbfebe74ea6e2bb5234d90a5e7d6c"),
+            from_hex("0c0bbb0aa000ae9ca700d753cafc556525a5348bb4ad4ece56b9"),
+          },
+          {
+            from_hex("0b0baaa000e025c92b32b421efe6d6e1b9a04949498acaa9be"),
+            from_hex("0bbbaaa000d079005f5e967a5408b29de179a69db552f41843"),
+            from_hex("0c0bbbaaa000258742303cfbbcbf26ab10b490e866729242779b"),
+          },
+        },
+      } } },
+    { CipherSuite::AES_GCM_256_SHA512,
+      { {
+        {
+          {
+            from_hex("0b0b00a0008aa688a274acba1d92314a0f98794e1e50191392"),
+            from_hex("0bbb00a0005437ed5f1545ce989de0eb38f02f1ed06c74bcbe"),
+            from_hex("0c0bbb00a000439084e68b408b2430e9077739d9d0d53129188e"),
+          },
+          {
+            from_hex("0b0b0aa000af72f544b51c937d217ab488ed44db7c18b5fe16"),
+            from_hex("0bbb0aa00046c7750b1951594d8a12d76e4366b248d4422793"),
+            from_hex("0c0bbb0aa0002c5825a674df250f82b7b51dd01583689664db7c"),
+          },
+          {
+            from_hex("0b0baaa0008036596f12dcc552d0f03a794430d629439a205d"),
+            from_hex("0bbbaaa0009237f7cb947e9aedb97b0bf69557604c2c3356f5"),
+            from_hex("0c0bbbaaa000de9955378ee32a3aef148cd7ce05b93ee2508a74"),
+          },
+        },
+        {
+          {
+            from_hex("0b0b00af001c3d824df4c26e2d76d65f40840491fb577e7d26"),
+            from_hex("0bbb00af001e14b7f4ddc1b8fe5c29d279c7f35f46652b6265"),
+            from_hex("0c0bbb00af00d638340784a28863256a470667cb8521dd682f2d"),
+          },
+          {
+            from_hex("0b0b0aaf00f5ace84a9ac311216588637d012519d42461a698"),
+            from_hex("0bbb0aaf006f2d1fc9a688382e5b85b01d9f49563a0aa80d29"),
+            from_hex("0c0bbb0aaf00d8a865e3655d0a322106d35c3375ac3837a852c0"),
+          },
+          {
+            from_hex("0b0baaaf00a9b54ca17d87a0f4a64260fdb374ff60331a06c4"),
+            from_hex("0bbbaaaf00450e533cc76f31ffcd7080c2ec3d3e6ace9e9638"),
+            from_hex("0c0bbbaaaf0048a8028b1a28719158ab19c6fd1a0bf2e532f26b"),
+          },
+        },
+        {
+          {
+            from_hex("0b0b00a00015df4f7a226bd82e403c95eb0473c3b499b91c88"),
+            from_hex("0bbb00a00052e7cd8bb8cb68fde112740b154fd7ac63dfe45d"),
+            from_hex("0c0bbb00a00065539ae6be900e527bed4df63f9d5a28f0308659"),
+          },
+          {
+            from_hex("0b0b0aa0003617ffb2846dff0d01f73cb768fe332fb25187da"),
+            from_hex("0bbb0aa0006f6f9695211ec704a8374eea34768a29d28015b1"),
+            from_hex("0c0bbb0aa000dd52ace0a6cec57446268a52e8b0ae9f88c541d6"),
+          },
+          {
+            from_hex("0b0baaa000e37e4c8e7805ed3ec6d26f828825855c5f7b1be5"),
+            from_hex("0bbbaaa00028b3993f0ff97d32547dc88b1479ab6f5e7626c6"),
+            from_hex("0c0bbbaaa0001e93ae8c8daa541697b206ccff31ff12050ac035"),
+          },
+        },
+      } } },
   };
 
   auto pt_out = bytes(plaintext.size());
@@ -608,8 +608,8 @@ TEST_CASE("MLS Known-Answer with Context")
 
         CHECK(tc.epochs[i][j].size() == context_ids.size());
         for (size_t k = 0; k < tc.epochs[i][j].size(); k++) {
-          auto encrypted =
-            ctx.protect(epoch_ids[i], sender_ids[j], context_ids[k], ct_out, plaintext);
+          auto encrypted = ctx.protect(
+            epoch_ids[i], sender_ids[j], context_ids[k], ct_out, plaintext);
           CHECK(tc.epochs[i][j][k] == to_bytes(encrypted));
 
           auto decrypted = ctx.unprotect(pt_out, tc.epochs[i][j][k]);
@@ -656,14 +656,16 @@ TEST_CASE("MLS Round-Trip with context")
       member_b.add_epoch(epoch_id, sframe_epoch_secret);
 
       for (int i = 0; i < epoch_rounds; i++) {
-        auto encrypted_ab_0 =
-          member_a_0.protect(epoch_id, sender_id_a, context_id_0, ct_out_0, plaintext);
-        auto decrypted_ab_0 = to_bytes(member_b.unprotect(pt_out, encrypted_ab_0));
+        auto encrypted_ab_0 = member_a_0.protect(
+          epoch_id, sender_id_a, context_id_0, ct_out_0, plaintext);
+        auto decrypted_ab_0 =
+          to_bytes(member_b.unprotect(pt_out, encrypted_ab_0));
         CHECK(plaintext == decrypted_ab_0);
 
-        auto encrypted_ab_1 =
-          member_a_1.protect(epoch_id, sender_id_a, context_id_1, ct_out_1, plaintext);
-        auto decrypted_ab_1 = to_bytes(member_b.unprotect(pt_out, encrypted_ab_1));
+        auto encrypted_ab_1 = member_a_1.protect(
+          epoch_id, sender_id_a, context_id_1, ct_out_1, plaintext);
+        auto decrypted_ab_1 =
+          to_bytes(member_b.unprotect(pt_out, encrypted_ab_1));
         CHECK(plaintext == decrypted_ab_1);
 
         std::cout << encrypted_ab_0 << " " << encrypted_ab_1 << std::endl;
@@ -671,8 +673,10 @@ TEST_CASE("MLS Round-Trip with context")
 
         auto encrypted_ba =
           member_b.protect(epoch_id, sender_id_b, ct_out_0, plaintext);
-        auto decrypted_ba_0 = to_bytes(member_a_0.unprotect(pt_out, encrypted_ba));
-        auto decrypted_ba_1 = to_bytes(member_a_1.unprotect(pt_out, encrypted_ba));
+        auto decrypted_ba_0 =
+          to_bytes(member_a_0.unprotect(pt_out, encrypted_ba));
+        auto decrypted_ba_1 =
+          to_bytes(member_a_1.unprotect(pt_out, encrypted_ba));
         CHECK(plaintext == decrypted_ba_0);
         CHECK(plaintext == decrypted_ba_1);
       }

--- a/test/sframe.cpp
+++ b/test/sframe.cpp
@@ -1,6 +1,7 @@
 #include <doctest/doctest.h>
 #include <sframe/sframe.h>
 
+#include <iostream>
 #include <map>       // for map
 #include <stdexcept> // for invalid_argument
 #include <string>    // for basic_string, operator==
@@ -191,78 +192,78 @@ TEST_CASE("MLS Known-Answer")
     0xaaa,
   };
   const std::map<CipherSuite, KnownAnswerTest> cases{
-    { CipherSuite::AES_CM_128_HMAC_SHA256_4,
-      { {
-        {
-          from_hex("09a000c92bf2b7154e0356"),
-          from_hex("0a0aa000c84890cf4a814ce0"),
-          from_hex("0aaaa0004361be8c2c549ae5"),
-        },
-        {
-          from_hex("09af0086adc8a87988307c"),
-          from_hex("0a0aaf006870557dd62e9409"),
-          from_hex("0aaaaf00a0e68b60eab24b27"),
-        },
-        {
-          from_hex("09a0001ad5829b23a11c33"),
-          from_hex("0a0aa0004769a13c95568e30"),
-          from_hex("0aaaa000586b97fa7f7fe096"),
-        },
-      } } },
-    { CipherSuite::AES_CM_128_HMAC_SHA256_8,
-      { {
-        {
-          from_hex("09a000c92bf2b7154e0356b4be009e"),
-          from_hex("0a0aa000c84890cf4a814ce031fae9f7"),
-          from_hex("0aaaa0004361be8c2c549ae53384b5f1"),
-        },
-        {
-          from_hex("09af0086adc8a87988307c147e8138"),
-          from_hex("0a0aaf006870557dd62e94097fdfaae8"),
-          from_hex("0aaaaf00a0e68b60eab24b275b63f964"),
-        },
-        {
-          from_hex("09a0001ad5829b23a11c33a5ac2f11"),
-          from_hex("0a0aa0004769a13c95568e30f9bafee2"),
-          from_hex("0aaaa000586b97fa7f7fe0965aee99da"),
-        },
-      } } },
-    { CipherSuite::AES_GCM_128_SHA256,
-      { {
-        {
-          from_hex("09a000bb7d6b3b4f32219f00516841cca349101f942ba1"),
-          from_hex("0a0aa000382032d088cb627c73b2c55968092d7039538f02"),
-          from_hex("0aaaa0006aa1aa44bbd1911b07ad876350c29790dad1fa04"),
-        },
-        {
-          from_hex("09af0077d0682046fdb1e08315c63b6c5f9f205a9e76c4"),
-          from_hex("0a0aaf00a99857f0a8aa0b2d0b5825ea2c0d71621f2bb7aa"),
-          from_hex("0aaaaf00662bf029595d34ea58a68edc7390c78e0fcc6de4"),
-        },
-        {
-          from_hex("09a0000661fb1f7b2b2dd820b225f5239cafc817da7821"),
-          from_hex("0a0aa0008140a14bb80a6d5793637d820de7c01df4f7f676"),
-          from_hex("0aaaa00084da92dbd31c174d3d7423c9470a48849c5c83b3"),
-        },
-      } } },
-    { CipherSuite::AES_GCM_256_SHA512,
-      { {
-        {
-          from_hex("09a000414462ccdfcb5473b8e0e4f686362e35a2985182"),
-          from_hex("0a0aa000c013c6d92f0683dbf87ccca3c2c11d3eca3c382f"),
-          from_hex("0aaaa0009a2a9ab03c3eca040928d8ef17ea531696b8163a"),
-        },
-        {
-          from_hex("09af00466bc33b10ec4405e4ff7241d11c63b21192b535"),
-          from_hex("0a0aaf00f7219487f1bf6ccec5c40888bcd79bb135900e02"),
-          from_hex("0aaaaf0043a23ff53ae88f41084ad503f1ec82613983b00b"),
-        },
-        {
-          from_hex("09a0004f4d239d260255899228d119099fa23f09d8b880"),
-          from_hex("0a0aa000b592b5e3bc31c7ac13eea1e69e83826233f90a4d"),
-          from_hex("0aaaa000fd95ba9acefc244e4652db355d4ce0a5c5137492"),
-        },
-      } } },
+{ CipherSuite::AES_CM_128_HMAC_SHA256_4,
+  { {
+    {
+      from_hex("09a000a099f9cfcebe0016"),
+      from_hex("0a0aa000102ea6af868bda78"),
+      from_hex("0aaaa0009c0aa3c3dc43d075"),
+    },
+    {
+      from_hex("09af008414bb5861dec7d0"),
+      from_hex("0a0aaf004486695c578d1d7b"),
+      from_hex("0aaaaf00da9a202a28d52f29"),
+    },
+    {
+      from_hex("09a0008f7b4591e6f1bc5b"),
+      from_hex("0a0aa00039743979f1e9e9f5"),
+      from_hex("0aaaa000658794f1db8a4553"),
+    },
+  } } },
+{ CipherSuite::AES_CM_128_HMAC_SHA256_8,
+  { {
+    {
+      from_hex("09a000a099f9cfcebe0016ec6d4089"),
+      from_hex("0a0aa000102ea6af868bda7839a896e4"),
+      from_hex("0aaaa0009c0aa3c3dc43d07567ed7c50"),
+    },
+    {
+      from_hex("09af008414bb5861dec7d0e1e2bc71"),
+      from_hex("0a0aaf004486695c578d1d7b90e9b557"),
+      from_hex("0aaaaf00da9a202a28d52f29f4bf0ddf"),
+    },
+    {
+      from_hex("09a0008f7b4591e6f1bc5bd3568ba2"),
+      from_hex("0a0aa00039743979f1e9e9f57e4a5553"),
+      from_hex("0aaaa000658794f1db8a45534bfde555"),
+    },
+  } } },
+{ CipherSuite::AES_GCM_128_SHA256,
+  { {
+    {
+      from_hex("09a000f32e41cdb15b8c9c3bd57e4ed008f056fa263df3"),
+      from_hex("0a0aa000ad96fdf39faf8711d53279f8549ad4fb23f1f8aa"),
+      from_hex("0aaaa000c79771b0d97bf9035b920fb1bb565c4025cf8a47"),
+    },
+    {
+      from_hex("09af00feb0c2b242d3c8a9aec464fc92f55c9539d5caa8"),
+      from_hex("0a0aaf00c0afce4867ee782c45de14a1990ea5576f41fa52"),
+      from_hex("0aaaaf00d034912de869721e8ea2e5724d3eb69f4b7c7e6a"),
+    },
+    {
+      from_hex("09a00003fa0e4e4c36bc0aed031c56b1db488c525831b3"),
+      from_hex("0a0aa000184a009fdfa7d0ee2c36a9e9ee1d21663b4dcde1"),
+      from_hex("0aaaa0008f2e842d16d4ec69b23623b7bd9838e4f906bab1"),
+    },
+  } } },
+{ CipherSuite::AES_GCM_256_SHA512,
+  { {
+    {
+      from_hex("09a0007878e804d643a86c6ec1711ee2b6a9e6aa4d9be8"),
+      from_hex("0a0aa00083f5083c175e74c484d837e35d6e359ef5dfc66a"),
+      from_hex("0aaaa0000144a05a1c3c75691b5597d01d1517d5ebc92460"),
+    },
+    {
+      from_hex("09af002a2be564b2a788abd838f01cfcec315563bdf708"),
+      from_hex("0a0aaf00ca411f242081522129078b6c5239f5e8baf10d67"),
+      from_hex("0aaaaf0011a1a4ea5a7796589931acc62c3a6ccf5008e3cc"),
+    },
+    {
+      from_hex("09a0003f5d9b66df64c7cb3cce99952028990a3869d3a8"),
+      from_hex("0a0aa0000b8a680c5bfc4efb8fb68041b5f63441e9aaaa85"),
+      from_hex("0aaaa00061c7c6a5b2882f037aea330533e0381d1f25e074"),
+    },
+  } } },
   };
 
   auto pt_out = bytes(plaintext.size());
@@ -282,6 +283,7 @@ TEST_CASE("MLS Known-Answer")
       for (size_t j = 0; j < tc.epochs[i].size(); j++) {
         auto encrypted =
           ctx.protect(epoch_ids[i], sender_ids[j], ct_out, plaintext);
+        std::cout << tc.epochs[i][j] << " " << to_bytes(encrypted) << std::endl;
         CHECK(tc.epochs[i][j] == to_bytes(encrypted));
 
         auto decrypted = ctx.unprotect(pt_out, tc.epochs[i][j]);
@@ -325,10 +327,294 @@ TEST_CASE("MLS Round-Trip")
         auto decrypted_ab = member_b.unprotect(pt_out, encrypted_ab);
         CHECK(plaintext == to_bytes(decrypted_ab));
 
+        std::cout << encrypted_ab << std::endl;
+
         auto encrypted_ba =
           member_b.protect(epoch_id, sender_id_b, ct_out, plaintext);
         auto decrypted_ba = member_a.unprotect(pt_out, encrypted_ba);
         CHECK(plaintext == to_bytes(decrypted_ba));
+      }
+    }
+  }
+}
+
+TEST_CASE("MLS Known-Answer with Context")
+{
+  struct KnownAnswerTest
+  {
+    using ContextCases = std::vector<bytes>;
+    using SenderCases = std::vector<ContextCases>;
+    std::vector<SenderCases> epochs;
+  };
+
+  const auto plaintext = from_hex("00010203");
+  const auto epoch_bits = 4;
+  //const auto sender_bits = 12;
+  const auto epoch_ids = std::vector<MLSContext::EpochID>{
+    0x00,
+    0x0f,
+    0x10,
+  };
+  const auto epoch_secrets = std::vector<bytes>{
+    from_hex("00000000000000000000000000000000"),
+    from_hex("0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f"),
+    from_hex("10101010101010101010101010101010"),
+  };
+  const auto sender_ids = std::vector<MLSContext::SenderID>{
+    0x0a,
+    0xaa,
+    0xaaa,
+  };
+  const auto context_ids = std::vector<MLSContext::ContextID>{
+    0x0b,
+    0xbb,
+    0xbbb,
+  };
+  const auto sender_bits = 12;
+  const std::map<CipherSuite, KnownAnswerTest> cases{
+{ CipherSuite::AES_CM_128_HMAC_SHA256_4,
+  { {
+    {
+      {
+        from_hex("0b0b00a000e78b66f2396ad3fb"),
+        from_hex("0bbb00a000627f7a610c7d5114"),
+        from_hex("0c0bbb00a000010247612644e928"),
+      },
+      {
+        from_hex("0b0b0aa000065aacf40d149781"),
+        from_hex("0bbb0aa0003db4ff6316a3b4aa"),
+        from_hex("0c0bbb0aa000804e43f1e3b30c01"),
+      },
+      {
+        from_hex("0b0baaa0008ee32c082a6baced"),
+        from_hex("0bbbaaa000d158bf21f2be0aff"),
+        from_hex("0c0bbbaaa000ddb84e167700afcb"),
+      },
+    },
+    {
+      {
+        from_hex("0b0b00af00645a02cbd4dd5469"),
+        from_hex("0bbb00af00436630a155d66c9e"),
+        from_hex("0c0bbb00af000160419ebc8f5181"),
+      },
+      {
+        from_hex("0b0b0aaf009c1c9c9a6103a004"),
+        from_hex("0bbb0aaf003f0045b076151853"),
+        from_hex("0c0bbb0aaf00e638bf4dbafe35dc"),
+      },
+      {
+        from_hex("0b0baaaf002c21652122601e05"),
+        from_hex("0bbbaaaf001a40ca810397ca64"),
+        from_hex("0c0bbbaaaf00cbdcb9e4e401ee56"),
+      },
+    },
+    {
+      {
+        from_hex("0b0b00a000dadd1533c0418d7a"),
+        from_hex("0bbb00a000144ac3cfd5e4a563"),
+        from_hex("0c0bbb00a000b753901426810fcd"),
+      },
+      {
+        from_hex("0b0b0aa00006be6cd4471e3028"),
+        from_hex("0bbb0aa0008cea2fb844ed6440"),
+        from_hex("0c0bbb0aa000ad1376f533ebf44a"),
+      },
+      {
+        from_hex("0b0baaa000a20b1f3ed8499f8a"),
+        from_hex("0bbbaaa0006f311c5a7aaf0289"),
+        from_hex("0c0bbbaaa000ede89b44263ee250"),
+      },
+    },
+  } } },
+{ CipherSuite::AES_CM_128_HMAC_SHA256_8,
+  { {
+    {
+      {
+        from_hex("0b0b00a000e78b66f2396ad3fbb4a56007"),
+        from_hex("0bbb00a000627f7a610c7d51149811b320"),
+        from_hex("0c0bbb00a000010247612644e9287540ce73"),
+      },
+      {
+        from_hex("0b0b0aa000065aacf40d14978172ebf918"),
+        from_hex("0bbb0aa0003db4ff6316a3b4aadd53d398"),
+        from_hex("0c0bbb0aa000804e43f1e3b30c0197cfd76b"),
+      },
+      {
+        from_hex("0b0baaa0008ee32c082a6baced795e34b5"),
+        from_hex("0bbbaaa000d158bf21f2be0affa7f4a66d"),
+        from_hex("0c0bbbaaa000ddb84e167700afcbc8d2fe11"),
+      },
+    },
+    {
+      {
+        from_hex("0b0b00af00645a02cbd4dd546959a200ef"),
+        from_hex("0bbb00af00436630a155d66c9e16890d09"),
+        from_hex("0c0bbb00af000160419ebc8f51814fb3271a"),
+      },
+      {
+        from_hex("0b0b0aaf009c1c9c9a6103a004cab06cd0"),
+        from_hex("0bbb0aaf003f0045b07615185317303eb9"),
+        from_hex("0c0bbb0aaf00e638bf4dbafe35dc1853cc73"),
+      },
+      {
+        from_hex("0b0baaaf002c21652122601e056a27bc1d"),
+        from_hex("0bbbaaaf001a40ca810397ca646e2b08c3"),
+        from_hex("0c0bbbaaaf00cbdcb9e4e401ee566e91e386"),
+      },
+    },
+    {
+      {
+        from_hex("0b0b00a000dadd1533c0418d7ab42e193b"),
+        from_hex("0bbb00a000144ac3cfd5e4a563b8766bad"),
+        from_hex("0c0bbb00a000b753901426810fcdd91261a2"),
+      },
+      {
+        from_hex("0b0b0aa00006be6cd4471e30285c6e51df"),
+        from_hex("0bbb0aa0008cea2fb844ed64406dc495b6"),
+        from_hex("0c0bbb0aa000ad1376f533ebf44a3f778c81"),
+      },
+      {
+        from_hex("0b0baaa000a20b1f3ed8499f8a740a02a5"),
+        from_hex("0bbbaaa0006f311c5a7aaf02895ea699ed"),
+        from_hex("0c0bbbaaa000ede89b44263ee25013fc615d"),
+      },
+    },
+  } } },
+{ CipherSuite::AES_GCM_128_SHA256,
+  { {
+    {
+      {
+        from_hex("0b0b00a0006ecb201768cf6a0f14bbee09ad490c5a4e215650"),
+        from_hex("0bbb00a000bc4944c23dd62883911c247c4d42fb9cd1a60883"),
+        from_hex("0c0bbb00a000ea232bd73f103aebef947a487de72cbf4fae7add"),
+      },
+      {
+        from_hex("0b0b0aa000d0ead9e0b2bb2e52f82c1e377c27a49115694cc5"),
+        from_hex("0bbb0aa000fc894af5b173474384dc9b08d65875a85eeb42fa"),
+        from_hex("0c0bbb0aa0005df598693c6f1e5d567869302ad52064aba28157"),
+      },
+      {
+        from_hex("0b0baaa000051a97e25e94ab650b41890a0faa3747164ee2c0"),
+        from_hex("0bbbaaa000be93b0c301782fc4b7abf0a66b36120138fc86b9"),
+        from_hex("0c0bbbaaa0000e10273c8829af3eed30ad753763662e436a565d"),
+      },
+    },
+    {
+      {
+        from_hex("0b0b00af0034f26ddfee46ec7844f3d99e2895f1ba4325c74d"),
+        from_hex("0bbb00af00df339bf635ca2ae17d2f07b05e8edffd04518ae7"),
+        from_hex("0c0bbb00af000f3f4f26bb98f7a57870e376ddddf0da8ad9c6ae"),
+      },
+      {
+        from_hex("0b0b0aaf00d89a7e4ec825a3842f28c3ea40c8049f0cfe2084"),
+        from_hex("0bbb0aaf002278d74c851303f0e57553dc3e1933c3459a8487"),
+        from_hex("0c0bbb0aaf0076bccc828a1178dd36400b59a72d330e79e2bcc6"),
+      },
+      {
+        from_hex("0b0baaaf001f07a6d0f61dc787b82ca0a13b38093910df4eff"),
+        from_hex("0bbbaaaf00b69d6ada3cf060f7b010bb9b00fba19326e4d749"),
+        from_hex("0c0bbbaaaf00fd3231ba3a9a5db1e87a01d5ce4cd74f742ae46c"),
+      },
+    },
+    {
+      {
+        from_hex("0b0b00a000a054bb91c3097de21b58fea1fc1ccbc88570ebe5"),
+        from_hex("0bbb00a000e1d4a1511cf16bb6c222672a91d26ab33505c356"),
+        from_hex("0c0bbb00a0001865b9043654d287c8f3de32cc7cc6ad1bdfcfa9"),
+      },
+      {
+        from_hex("0b0b0aa0005fad155349c32ddd6dca93ac6a60c0c9b9533eb8"),
+        from_hex("0bbb0aa0003753e39c068bbfebe74ea6e2bb5234d90a5e7d6c"),
+        from_hex("0c0bbb0aa000ae9ca700d753cafc556525a5348bb4ad4ece56b9"),
+      },
+      {
+        from_hex("0b0baaa000e025c92b32b421efe6d6e1b9a04949498acaa9be"),
+        from_hex("0bbbaaa000d079005f5e967a5408b29de179a69db552f41843"),
+        from_hex("0c0bbbaaa000258742303cfbbcbf26ab10b490e866729242779b"),
+      },
+    },
+  } } },
+{ CipherSuite::AES_GCM_256_SHA512,
+  { {
+    {
+      {
+        from_hex("0b0b00a0008aa688a274acba1d92314a0f98794e1e50191392"),
+        from_hex("0bbb00a0005437ed5f1545ce989de0eb38f02f1ed06c74bcbe"),
+        from_hex("0c0bbb00a000439084e68b408b2430e9077739d9d0d53129188e"),
+      },
+      {
+        from_hex("0b0b0aa000af72f544b51c937d217ab488ed44db7c18b5fe16"),
+        from_hex("0bbb0aa00046c7750b1951594d8a12d76e4366b248d4422793"),
+        from_hex("0c0bbb0aa0002c5825a674df250f82b7b51dd01583689664db7c"),
+      },
+      {
+        from_hex("0b0baaa0008036596f12dcc552d0f03a794430d629439a205d"),
+        from_hex("0bbbaaa0009237f7cb947e9aedb97b0bf69557604c2c3356f5"),
+        from_hex("0c0bbbaaa000de9955378ee32a3aef148cd7ce05b93ee2508a74"),
+      },
+    },
+    {
+      {
+        from_hex("0b0b00af001c3d824df4c26e2d76d65f40840491fb577e7d26"),
+        from_hex("0bbb00af001e14b7f4ddc1b8fe5c29d279c7f35f46652b6265"),
+        from_hex("0c0bbb00af00d638340784a28863256a470667cb8521dd682f2d"),
+      },
+      {
+        from_hex("0b0b0aaf00f5ace84a9ac311216588637d012519d42461a698"),
+        from_hex("0bbb0aaf006f2d1fc9a688382e5b85b01d9f49563a0aa80d29"),
+        from_hex("0c0bbb0aaf00d8a865e3655d0a322106d35c3375ac3837a852c0"),
+      },
+      {
+        from_hex("0b0baaaf00a9b54ca17d87a0f4a64260fdb374ff60331a06c4"),
+        from_hex("0bbbaaaf00450e533cc76f31ffcd7080c2ec3d3e6ace9e9638"),
+        from_hex("0c0bbbaaaf0048a8028b1a28719158ab19c6fd1a0bf2e532f26b"),
+      },
+    },
+    {
+      {
+        from_hex("0b0b00a00015df4f7a226bd82e403c95eb0473c3b499b91c88"),
+        from_hex("0bbb00a00052e7cd8bb8cb68fde112740b154fd7ac63dfe45d"),
+        from_hex("0c0bbb00a00065539ae6be900e527bed4df63f9d5a28f0308659"),
+      },
+      {
+        from_hex("0b0b0aa0003617ffb2846dff0d01f73cb768fe332fb25187da"),
+        from_hex("0bbb0aa0006f6f9695211ec704a8374eea34768a29d28015b1"),
+        from_hex("0c0bbb0aa000dd52ace0a6cec57446268a52e8b0ae9f88c541d6"),
+      },
+      {
+        from_hex("0b0baaa000e37e4c8e7805ed3ec6d26f828825855c5f7b1be5"),
+        from_hex("0bbbaaa00028b3993f0ff97d32547dc88b1479ab6f5e7626c6"),
+        from_hex("0c0bbbaaa0001e93ae8c8daa541697b206ccff31ff12050ac035"),
+      },
+    },
+  } } },
+  };
+
+  auto pt_out = bytes(plaintext.size());
+  auto ct_out = bytes(plaintext.size() + max_overhead);
+
+  for (const auto& pair : cases) {
+    auto& suite = pair.first;
+    auto& tc = pair.second;
+
+    auto ctx = MLSContext(suite, epoch_bits);
+
+    CHECK(tc.epochs.size() == epoch_ids.size());
+    for (size_t i = 0; i < tc.epochs.size(); i++) {
+      ctx.add_epoch(epoch_ids[i], epoch_secrets[i], sender_bits);
+
+      CHECK(tc.epochs[i].size() == sender_ids.size());
+      for (size_t j = 0; j < tc.epochs[i].size(); j++) {
+
+        CHECK(tc.epochs[i][j].size() == context_ids.size());
+        for (size_t k = 0; k < tc.epochs[i][j].size(); k++) {
+          auto encrypted =
+            ctx.protect(epoch_ids[i], sender_ids[j], context_ids[k], ct_out, plaintext);
+          CHECK(tc.epochs[i][j][k] == to_bytes(encrypted));
+
+          auto decrypted = ctx.unprotect(pt_out, tc.epochs[i][j][k]);
+          CHECK(plaintext == to_bytes(decrypted));
+        }
       }
     }
   }
@@ -380,6 +666,7 @@ TEST_CASE("MLS Round-Trip with context")
         auto decrypted_ab_1 = to_bytes(member_b.unprotect(pt_out, encrypted_ab_1));
         CHECK(plaintext == decrypted_ab_1);
 
+        std::cout << encrypted_ab_0 << " " << encrypted_ab_1 << std::endl;
         CHECK(to_bytes(encrypted_ab_0) != to_bytes(encrypted_ab_1));
 
         auto encrypted_ba =


### PR DESCRIPTION
Real-time media systems often have strong decoupling between media sources after initial setup, including things like providing separate SRTP contexts for different media sources.  In SRTP, this is safe because the RTP SSRC is included in the nonce computation.  In MLS+SFrame, however, the key and nonce only depend on the secret and the sender ID in the KID, so having multiple contexts with the same secret and KID leads to nonce reuse.

Since the MLS+SFrame provisions derive per-sender-ID keys and senders will never use all `64-E` bits of KID, we can put a context distinguisher in the high-order bits of the sender ID that will cause independent contexts to have different keys and independent nonce sequences.  The resulting KID value will thus have the following form:

```
              sender_bits epoch_bits
              <---------> <-------->
+------------+-----------+----------+
| Context ID | Sender ID | Epoch ID |
+------------+-----------+----------+
```

The width of the "sender ID" part will depend on the size of the MLS group, and can vary by epoch, but it needs to be large enough to hold the MLS sender indices.  For example, a group with 256 participants needs `sender_bits >= 8`.

This has not been added to the specification yet.