### PR TITLE
Clean up structure and expose ContextBase

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ option(SANITIZERS "Enable sanitizers" OFF)
 ###
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 if (CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER_ID MATCHES "GNU")
   add_compile_options(-Wall -pedantic -Wextra -Werror -Wmissing-declarations)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ option(SANITIZERS "Enable sanitizers" OFF)
 ###
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 if (CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER_ID MATCHES "GNU")
   add_compile_options(-Wall -pedantic -Wextra -Werror -Wmissing-declarations)

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ ${BUILD_DIR}: CMakeLists.txt test/CMakeLists.txt
 	cmake -B${BUILD_DIR} .
 
 dev: CMakeLists.txt test/CMakeLists.txt
-	cmake -B${BUILD_DIR} -DCLANG_TIDY=ON -DTESTING=ON -DSANITIZERS=ON .
+	cmake -B${BUILD_DIR} -DCMAKE_BUILD_TYPE=Debug -DCLANG_TIDY=ON -DTESTING=ON -DSANITIZERS=ON .
 
 test: ${BUILD_DIR} test/*
 	cmake --build ${BUILD_DIR} --target sframe_test

--- a/include/sframe/sframe.h
+++ b/include/sframe/sframe.h
@@ -59,26 +59,28 @@ using Counter = uint64_t;
 class SFrame
 {
 protected:
-  CipherSuite suite;
-
   SFrame(CipherSuite suite_in);
   virtual ~SFrame();
 
-  struct KeyState
+  struct KeyAndSalt
   {
-    static KeyState from_base_key(CipherSuite suite, const bytes& base_key);
+    static KeyAndSalt from_base_key(CipherSuite suite, const bytes& base_key);
 
     bytes key;
     bytes salt;
     Counter counter;
   };
 
+  void add_key(KeyID kid, const bytes& key);
+
   output_bytes _protect(KeyID key_id,
+                        Counter ctr,
                         output_bytes ciphertext,
                         input_bytes plaintext);
   output_bytes _unprotect(output_bytes ciphertext, input_bytes plaintext);
 
-  virtual KeyState& get_state(KeyID key_id) = 0;
+  CipherSuite suite;
+  std::map<KeyID, KeyAndSalt> keys;
 };
 
 class Context : public SFrame
@@ -94,11 +96,10 @@ public:
   output_bytes unprotect(output_bytes plaintext, input_bytes ciphertext);
 
 private:
-  std::map<KeyID, KeyState> state;
-
-  KeyState& get_state(KeyID key_id) override;
+  std::map<KeyID, Counter> counters;
 };
 
+#if 0
 class MLSContext : public SFrame
 {
 public:
@@ -146,5 +147,6 @@ private:
   std::vector<std::unique_ptr<EpochKeys>> epoch_cache;
   KeyState& get_state(KeyID key_id) override;
 };
+#endif // 0
 
 } // namespace sframe

--- a/include/sframe/sframe.h
+++ b/include/sframe/sframe.h
@@ -76,7 +76,11 @@ private:
   const size_t counter_size;
   std::array<uint8_t, max_size> buffer;
 
-  Header(KeyID key_id_in, Counter counter_in, input_bytes encoded);
+  Header(KeyID key_id_in,
+         Counter counter_in,
+         size_t key_id_size_in,
+         size_t counter_size_in,
+         input_bytes encoded);
 };
 
 // ContextBase represents the core SFrame encryption logic.  It remembers a set
@@ -136,8 +140,8 @@ protected:
 };
 
 // MLSContext augments Context with logic for deriving keys from MLS.  Instead
-// of adding individual keys, salts, and key IDs, the caller adds a secret for an epoch,
-// and keys / salts / key IDs are derived as needed.
+// of adding individual keys, salts, and key IDs, the caller adds a secret for
+// an epoch, and keys / salts / key IDs are derived as needed.
 class MLSContext : protected Context
 {
 public:

--- a/src/crypto.cpp
+++ b/src/crypto.cpp
@@ -11,7 +11,8 @@ namespace sframe {
 
 openssl_error::openssl_error()
   : std::runtime_error(ERR_error_string(ERR_get_error(), nullptr))
-{}
+{
+}
 
 static const EVP_MD*
 openssl_digest_type(CipherSuite suite)
@@ -342,6 +343,22 @@ seal_aead(CipherSuite suite,
   }
 
   return ct.subspan(0, pt.size() + tag_size);
+}
+
+size_t
+overhead(CipherSuite suite)
+{
+  switch (suite) {
+    case CipherSuite::AES_CM_128_HMAC_SHA256_4:
+      return 4;
+
+    case CipherSuite::AES_CM_128_HMAC_SHA256_8:
+      return 8;
+
+    case CipherSuite::AES_GCM_128_SHA256:
+    case CipherSuite::AES_GCM_256_SHA512:
+      return 16;
+  }
 }
 
 output_bytes

--- a/src/crypto.h
+++ b/src/crypto.h
@@ -53,6 +53,9 @@ hkdf_expand(CipherSuite suite,
 /// AEAD Algorithms
 ///
 
+size_t
+overhead(CipherSuite suite);
+
 output_bytes
 seal(CipherSuite suite,
      const bytes& key,

--- a/src/header.cpp
+++ b/src/header.cpp
@@ -34,7 +34,8 @@ decode_uint(input_bytes data)
 }
 
 static size_t
-kid_size(KeyID key_id) {
+kid_size(KeyID key_id)
+{
   if (key_id < 0x08) {
     return 0;
   } else {
@@ -43,7 +44,8 @@ kid_size(KeyID key_id) {
 }
 
 static size_t
-ctr_size(Counter counter) {
+ctr_size(Counter counter)
+{
   const auto ctr_size = uint_size(counter);
   if (ctr_size == 0) {
     // CTR always takes at least one byte

--- a/src/header.cpp
+++ b/src/header.cpp
@@ -103,14 +103,18 @@ Header::parse(input_bytes buffer)
   }
   auto counter = Counter(decode_uint(buffer.subspan(1 + kid_size, ctr_size)));
 
-  return Header(key_id, counter, buffer.subspan(0, total_size));
+  return Header(key_id, counter, kid_size, ctr_size, buffer.subspan(0, total_size));
 }
 
-Header::Header(KeyID key_id_in, Counter counter_in, input_bytes encoded)
+Header::Header(KeyID key_id_in,
+               Counter counter_in,
+               size_t key_id_size,
+               size_t counter_size,
+               input_bytes encoded)
   : key_id(key_id_in)
   , counter(counter_in)
-  , key_id_size(kid_size(key_id))
-  , counter_size(ctr_size(counter))
+  , key_id_size(key_id_size)
+  , counter_size(counter_size)
 {
   std::copy(encoded.begin(), encoded.end(), buffer.begin());
 }

--- a/src/header.cpp
+++ b/src/header.cpp
@@ -33,26 +33,48 @@ decode_uint(input_bytes data)
   return val;
 }
 
-size_t
-Header::size() const
-{
-  auto kid_size = size_t(0);
-  if (key_id > 0x07) {
-    kid_size = uint_size(key_id);
+static size_t
+kid_size(KeyID key_id) {
+  if (key_id < 0x08) {
+    return 0;
+  } else {
+    return uint_size(key_id);
   }
-
-  const auto ctr_size = uint_size(counter);
-  if ((kid_size > 0x07) || (ctr_size > 0x07)) {
-    throw buffer_too_small_error("Header overflow");
-  }
-
-  return 1 + kid_size + ctr_size;
 }
 
-std::tuple<Header, input_bytes>
-Header::decode(input_bytes buffer)
+static size_t
+ctr_size(Counter counter) {
+  const auto ctr_size = uint_size(counter);
+  if (ctr_size == 0) {
+    // CTR always takes at least one byte
+    return 1;
+  }
+
+  return ctr_size;
+}
+
+Header::Header(KeyID key_id_in, Counter counter_in)
+  : key_id(key_id_in)
+  , counter(counter_in)
+  , key_id_size(kid_size(key_id))
+  , counter_size(ctr_size(counter))
 {
-  if (buffer.size() < Header::min_size) {
+  auto buffer_out = output_bytes(buffer);
+  buffer_out[0] = uint8_t((counter_size - 1) << 4);
+  if (key_id < 0x08) {
+    buffer_out[0] |= static_cast<uint8_t>(key_id);
+  } else {
+    buffer_out[0] |= static_cast<uint8_t>(0x08 | key_id_size);
+    encode_uint(key_id, buffer_out.subspan(1, key_id_size));
+  }
+
+  encode_uint(counter, buffer_out.subspan(1 + key_id_size, counter_size));
+}
+
+Header
+Header::parse(input_bytes buffer)
+{
+  if (buffer.size() < min_size) {
     throw buffer_too_small_error("Ciphertext too small to decode header");
   }
 
@@ -72,41 +94,35 @@ Header::decode(input_bytes buffer)
     kid_size = 0;
   }
 
+  auto total_size = 1 + ctr_size + kid_size;
+
   if (buffer.size() < 1 + kid_size + ctr_size) {
     throw buffer_too_small_error("Ciphertext too small to decode CTR");
   }
   auto counter = Counter(decode_uint(buffer.subspan(1 + kid_size, ctr_size)));
 
-  return std::make_tuple(Header{ key_id, counter },
-                         buffer.subspan(0, 1 + kid_size + ctr_size));
+  return Header(key_id, counter, buffer.subspan(0, total_size));
+}
+
+Header::Header(KeyID key_id_in, Counter counter_in, input_bytes encoded)
+  : key_id(key_id_in)
+  , counter(counter_in)
+  , key_id_size(kid_size(key_id))
+  , counter_size(ctr_size(counter))
+{
+  std::copy(encoded.begin(), encoded.end(), buffer.begin());
+}
+
+input_bytes
+Header::encoded() const
+{
+  return input_bytes(buffer).subspan(0, size());
 }
 
 size_t
-Header::encode(output_bytes buffer) const
+Header::size() const
 {
-  if (buffer.size() < size()) {
-    throw buffer_too_small_error("Buffer too small to encode header");
-  }
-
-  auto kid_size = uint_size(key_id);
-  if (key_id <= 0x07) {
-    kid_size = 0;
-    buffer[0] = static_cast<uint8_t>(key_id);
-  } else {
-    encode_uint(key_id, buffer.subspan(1, kid_size));
-    buffer[0] = static_cast<uint8_t>(0x08 | kid_size);
-  }
-
-  auto ctr_size = uint_size(counter);
-  if (ctr_size == 0) {
-    // Counter always takes at least one byte
-    ctr_size = 1;
-  }
-
-  encode_uint(counter, buffer.subspan(1 + kid_size, ctr_size));
-  buffer[0] |= uint8_t((ctr_size - 1) << 4);
-
-  return 1 + kid_size + ctr_size;
+  return 1 + key_id_size + counter_size;
 }
 
 } // namespace sframe

--- a/src/header.h
+++ b/src/header.h
@@ -12,13 +12,21 @@ struct Header
   const KeyID key_id;
   const Counter counter;
 
+  Header(KeyID key_id_in, Counter counter_in);
+  static Header parse(input_bytes buffer);
+
+  input_bytes encoded() const;
   size_t size() const;
 
-  static std::tuple<Header, input_bytes> decode(input_bytes data);
-  size_t encode(output_bytes buffer) const;
-
+private:
   static constexpr size_t min_size = 1;
   static constexpr size_t max_size = 1 + 7 + 7;
+
+  const size_t key_id_size;
+  const size_t counter_size;
+  std::array<uint8_t, max_size> buffer;
+
+  Header(KeyID key_id_in, Counter counter_in, input_bytes encoded);
 };
 
 } // namespace sframe

--- a/src/header.h
+++ b/src/header.h
@@ -4,29 +4,8 @@
 
 namespace sframe {
 
+// Exposed to sframe.cpp to aid in nonce formation
 void
 encode_uint(uint64_t val, output_bytes buffer);
-
-struct Header
-{
-  const KeyID key_id;
-  const Counter counter;
-
-  Header(KeyID key_id_in, Counter counter_in);
-  static Header parse(input_bytes buffer);
-
-  input_bytes encoded() const;
-  size_t size() const;
-
-private:
-  static constexpr size_t min_size = 1;
-  static constexpr size_t max_size = 1 + 7 + 7;
-
-  const size_t key_id_size;
-  const size_t counter_size;
-  std::array<uint8_t, max_size> buffer;
-
-  Header(KeyID key_id_in, Counter counter_in, input_bytes encoded);
-};
 
 } // namespace sframe

--- a/src/sframe.cpp
+++ b/src/sframe.cpp
@@ -66,8 +66,8 @@ form_nonce(Counter ctr, const bytes& salt)
 
 output_bytes
 ContextBase::protect(const Header& header,
-                 output_bytes ciphertext,
-                 input_bytes plaintext)
+                     output_bytes ciphertext,
+                     input_bytes plaintext)
 {
   if (ciphertext.size() < plaintext.size() + overhead(suite)) {
     throw buffer_too_small_error("Ciphertext too small for cipher overhead");
@@ -81,8 +81,8 @@ ContextBase::protect(const Header& header,
 
 output_bytes
 ContextBase::unprotect(const Header& header,
-                   output_bytes plaintext,
-                   input_bytes ciphertext)
+                       output_bytes plaintext,
+                       input_bytes ciphertext)
 {
   if (ciphertext.size() < overhead(suite)) {
     throw buffer_too_small_error("Ciphertext too small for cipher overhead");
@@ -171,7 +171,8 @@ Context::protect(KeyID key_id, output_bytes ciphertext, input_bytes plaintext)
 
   std::copy(aad.begin(), aad.end(), ciphertext.begin());
   auto inner_ciphertext = ciphertext.subspan(aad.size());
-  auto final_ciphertext = ContextBase::protect(header, inner_ciphertext, plaintext);
+  auto final_ciphertext =
+    ContextBase::protect(header, inner_ciphertext, plaintext);
   return ciphertext.subspan(0, aad.size() + final_ciphertext.size());
 }
 

--- a/src/sframe.cpp
+++ b/src/sframe.cpp
@@ -28,11 +28,13 @@ operator<<(std::ostream& str, const input_bytes data)
 
 unsupported_ciphersuite_error::unsupported_ciphersuite_error()
   : std::runtime_error("Unsupported ciphersuite")
-{}
+{
+}
 
 authentication_error::authentication_error()
   : std::runtime_error("AEAD authentication failure")
-{}
+{
+}
 
 ///
 /// Context
@@ -40,7 +42,8 @@ authentication_error::authentication_error()
 
 Context::Context(CipherSuite suite_in)
   : SFrame(suite_in)
-{}
+{
+}
 
 static const bytes sframe_label{
   0x53, 0x46, 0x72, 0x61, 0x6d, 0x65, 0x31, 0x30 // "SFrame10"
@@ -96,7 +99,8 @@ form_nonce(Counter ctr, const bytes& salt)
 
 SFrame::SFrame(CipherSuite suite_in)
   : suite(suite_in)
-{}
+{
+}
 
 SFrame::~SFrame() = default;
 
@@ -107,39 +111,45 @@ SFrame::add_key(KeyID key_id, const bytes& base_key)
 }
 
 output_bytes
-SFrame::_protect(KeyID key_id, Counter ctr, output_bytes ciphertext, input_bytes plaintext)
+SFrame::_protect(const Header& header,
+                 output_bytes ciphertext,
+                 input_bytes plaintext)
 {
-  const auto& key_and_salt = keys.at(key_id);
-  const auto header = Header{ key_id, ctr };
+  if (ciphertext.size() < plaintext.size() + overhead(suite)) {
+    throw buffer_too_small_error("Ciphertext too small for cipher overhead");
+  }
+
+  const auto& key_and_salt = keys.at(header.key_id);
   const auto aad = header.encoded();
+  const auto nonce = form_nonce(header.counter, key_and_salt.salt);
+  const auto ct = seal(suite, key_and_salt.key, nonce, ciphertext, aad, plaintext);
 
-  if (ciphertext.size() < aad.size()) {
-    throw buffer_too_small_error("Ciphertext too small for SFrame header");
-  }
+  std::cout << "===" << std::endl
+            << "key " << key_and_salt.key << std::endl
+            << "salt " << key_and_salt.salt << std::endl
+            << "ct " << ct << std::endl
+            << std::endl;
 
-  std::copy(aad.begin(), aad.end(), ciphertext.begin());
-  auto inner_ciphertext = ciphertext.subspan(aad.size());
-
-  if (inner_ciphertext.size() < plaintext.size() + overhead(suite)) {
-    throw buffer_too_small_error("Ciphertext too small for ciphertext");
-  }
-
-  const auto nonce = form_nonce(ctr, key_and_salt.salt);
-  auto final_ciphertext =
-    seal(suite, key_and_salt.key, nonce, inner_ciphertext, aad, plaintext);
-  return ciphertext.subspan(0, aad.size() + final_ciphertext.size());
+  return ct;
 }
 
 output_bytes
-SFrame::_unprotect(output_bytes plaintext, input_bytes ciphertext)
+SFrame::_unprotect(const Header& header,
+                   output_bytes plaintext,
+                   input_bytes ciphertext)
 {
-  const auto header = Header::parse(ciphertext);
-  const auto aad = header.encoded();
-  const auto inner_ciphertext = ciphertext.subspan(aad.size());
+  if (ciphertext.size() < overhead(suite)) {
+    throw buffer_too_small_error("Ciphertext too small for cipher overhead");
+  }
+
+  if (plaintext.size() < ciphertext.size() - overhead(suite)) {
+    throw buffer_too_small_error("Plaintext too small for decrypted value");
+  }
 
   const auto& key_and_salt = keys.at(header.key_id);
+  const auto aad = header.encoded();
   const auto nonce = form_nonce(header.counter, key_and_salt.salt);
-  return open(suite, key_and_salt.key, nonce, plaintext, aad, inner_ciphertext);
+  return open(suite, key_and_salt.key, nonce, plaintext, aad, ciphertext);
 }
 
 void
@@ -152,25 +162,35 @@ Context::add_key(KeyID key_id, const bytes& base_key)
 output_bytes
 Context::protect(KeyID key_id, output_bytes ciphertext, input_bytes plaintext)
 {
-  const auto ctr = counters.at(key_id);
+  const auto counter = counters.at(key_id);
   counters.at(key_id) += 1;
 
-  return _protect(key_id, ctr, ciphertext, plaintext);
+  const auto header = Header{ key_id, counter };
+  const auto aad = header.encoded();
+  if (ciphertext.size() < aad.size()) {
+    throw buffer_too_small_error("Ciphertext too small for SFrame header");
+  }
+
+  std::copy(aad.begin(), aad.end(), ciphertext.begin());
+  auto inner_ciphertext = ciphertext.subspan(aad.size());
+  auto final_ciphertext = _protect(header, inner_ciphertext, plaintext);
+  return ciphertext.subspan(0, aad.size() + final_ciphertext.size());
 }
 
 output_bytes
 Context::unprotect(output_bytes plaintext, input_bytes ciphertext)
 {
-  return _unprotect(plaintext, ciphertext);
+  const auto header = Header::parse(ciphertext);
+  const auto inner_ciphertext = ciphertext.subspan(header.size());
+  return _unprotect(header, plaintext, inner_ciphertext);
 }
 
-#if 0
 ///
 /// MLSContext
 ///
 
 MLSContext::MLSContext(CipherSuite suite_in, size_t epoch_bits_in)
-  : SFrame(suite_in)
+  : Context(suite_in)
   , epoch_bits(epoch_bits_in)
   , epoch_mask((size_t(1) << epoch_bits_in) - 1)
   , epoch_cache(size_t(1) << epoch_bits_in)
@@ -183,9 +203,7 @@ MLSContext::MLSContext(CipherSuite suite_in, size_t epoch_bits_in)
 void
 MLSContext::add_epoch(EpochID epoch_id, const bytes& sframe_epoch_secret)
 {
-  auto epoch_index = epoch_id & epoch_mask;
-  epoch_cache.at(epoch_index)
-    .reset(new EpochKeys(epoch_id, sframe_epoch_secret, 0));
+  add_epoch(epoch_id, sframe_epoch_secret, 0);
 }
 
 void
@@ -194,8 +212,14 @@ MLSContext::add_epoch(EpochID epoch_id,
                       size_t sender_bits)
 {
   auto epoch_index = epoch_id & epoch_mask;
-  epoch_cache.at(epoch_index)
-    .reset(new EpochKeys(epoch_id, sframe_epoch_secret, sender_bits));
+  auto& epoch = epoch_cache.at(epoch_index);
+
+  if (epoch) {
+    purge_epoch(epoch->full_epoch);
+  }
+
+  epoch
+    .reset(new EpochKeys(epoch_id, sframe_epoch_secret, epoch_bits, sender_bits));
 }
 
 void
@@ -203,6 +227,7 @@ MLSContext::purge_before(EpochID keeper)
 {
   for (auto& ptr : epoch_cache) {
     if (ptr && ptr->full_epoch < keeper) {
+      purge_epoch(ptr->full_epoch);
       ptr.reset(nullptr);
     }
   }
@@ -214,9 +239,7 @@ MLSContext::protect(EpochID epoch_id,
                     output_bytes ciphertext,
                     input_bytes plaintext)
 {
-  auto epoch_index = epoch_id & epoch_mask;
-  auto key_id = KeyID((uint64_t(sender_id) << epoch_bits) | epoch_index);
-  return _protect(key_id, ciphertext, plaintext);
+  return protect(epoch_id, sender_id, 0, ciphertext, plaintext);
 }
 
 output_bytes
@@ -226,43 +249,70 @@ MLSContext::protect(EpochID epoch_id,
                     output_bytes ciphertext,
                     input_bytes plaintext)
 {
-  auto epoch_index = epoch_id & epoch_mask;
-  auto& epoch = epoch_cache.at(epoch_index);
-  if (!epoch) {
-    throw invalid_parameter_error(
-      "Unknown epoch. epoch_index: " + std::to_string(epoch_index) +
-      ", sender_id:" + std::to_string(sender_id));
-  }
-
-  auto sender_bits = epoch->sender_bits;
-  if (sender_id >= (uint64_t(1) << sender_bits)) {
-    throw invalid_parameter_error(
-      "Sender ID too large: " + std::to_string(sender_id) + " > " +
-      std::to_string(1 << sender_bits) +
-      " sender_bits:" + std::to_string(sender_bits));
-  }
-
-  auto context_part = uint64_t(context_id) << (epoch_bits + sender_bits);
-  auto sender_part = uint64_t(sender_id) << epoch_bits;
-  auto key_id = KeyID(context_part | sender_part | epoch_index);
-  return _protect(key_id, ciphertext, plaintext);
+  auto key_id = form_key_id(epoch_id, sender_id, context_id);
+  ensure_key(key_id);
+  return Context::protect(key_id, ciphertext, plaintext);
 }
 
 output_bytes
 MLSContext::unprotect(output_bytes plaintext, input_bytes ciphertext)
 {
-  return _unprotect(plaintext, ciphertext);
+  const auto header = Header::parse(ciphertext);
+  const auto inner_ciphertext = ciphertext.subspan(header.size());
+
+  ensure_key(header.key_id);
+  return _unprotect(header, plaintext, inner_ciphertext);
 }
 
 MLSContext::EpochKeys::EpochKeys(MLSContext::EpochID full_epoch_in,
                                  bytes sframe_epoch_secret_in,
+                                 size_t epoch_bits,
                                  size_t sender_bits_in)
   : full_epoch(full_epoch_in)
   , sframe_epoch_secret(std::move(sframe_epoch_secret_in))
   , sender_bits(sender_bits_in)
-{}
+{
+  static constexpr uint64_t one = 1;
+  static constexpr size_t key_id_bits = 64;
 
-SFrame::KeyState&
+  if (sender_bits > key_id_bits - epoch_bits) {
+    throw invalid_parameter_error("Sender ID field too large");
+  }
+
+  // XXX(RLB) We use 0 as a signifier that the sender takes the rest of the key
+  // ID, and context IDs are not allowed.  This would be more explicit if we
+  // used std::optional, but would require more modern C++.
+  if (sender_bits == 0) {
+    sender_bits = key_id_bits - epoch_bits;
+  }
+
+  context_bits = key_id_bits - sender_bits - epoch_bits;
+  max_sender_id = (one << (sender_bits + 1)) - 1;
+  max_context_id = (one << (context_bits + 1)) - 1;
+}
+
+bytes
+MLSContext::EpochKeys::base_key(CipherSuite ciphersuite,
+                                SenderID sender_id) const
+{
+  auto hash_size = cipher_digest_size(ciphersuite);
+  auto enc_sender_id = bytes(8);
+  encode_uint(sender_id, enc_sender_id);
+
+  auto base_key = hkdf_expand(
+    ciphersuite, sframe_epoch_secret, enc_sender_id, hash_size);
+
+  std::cout << "===" << std::endl
+            << "ciphersuite " << uint16_t(ciphersuite) << std::endl
+            << "sframe_epoch_secret " << sframe_epoch_secret << std::endl
+            << "enc_sender_id " << enc_sender_id << std::endl
+            << "hash_size " << hash_size << std::endl
+            << std::endl;
+
+  return base_key;
+}
+
+SFrame::KeyAndSalt&
 MLSContext::EpochKeys::get(CipherSuite ciphersuite, SenderID sender_id)
 {
   auto it = sender_keys.find(sender_id);
@@ -276,13 +326,101 @@ MLSContext::EpochKeys::get(CipherSuite ciphersuite, SenderID sender_id)
 
   auto sender_base_key =
     hkdf_expand(ciphersuite, sframe_epoch_secret, enc_sender_id, hash_size);
-  auto key_state = KeyState::from_base_key(ciphersuite, sender_base_key);
+  auto key_state = KeyAndSalt::from_base_key(ciphersuite, sender_base_key);
   sender_keys.insert({ sender_id, std::move(key_state) });
 
   return sender_keys.at(sender_id);
 }
 
-SFrame::KeyState&
+void
+MLSContext::purge_epoch(EpochID epoch_id)
+{
+  const auto drop_bits = epoch_id & epoch_bits;
+
+  // Remove keys for this epoch
+  for (auto i = keys.begin(); i != keys.end();) {
+    if ((i->first & epoch_bits) == drop_bits) {
+      i = keys.erase(i);
+    } else {
+      ++i;
+    }
+  }
+
+  // Remove counters for this epoch
+  for (auto i = counters.begin(); i != counters.end();) {
+    if ((i->first & epoch_bits) == drop_bits) {
+      i = counters.erase(i);
+    } else {
+      ++i;
+    }
+  }
+}
+
+KeyID
+MLSContext::form_key_id(EpochID epoch_id,
+                        SenderID sender_id,
+                        ContextID context_id) const
+{
+  auto epoch_index = epoch_id & epoch_mask;
+  auto& epoch = epoch_cache.at(epoch_index);
+  if (!epoch) {
+    throw invalid_parameter_error(
+      "Unknown epoch. epoch_index: " + std::to_string(epoch_index) +
+      ", sender_id:" + std::to_string(sender_id));
+  }
+
+  if (sender_id > epoch->max_sender_id) {
+    throw invalid_parameter_error("Sender ID overflow");
+  }
+
+  if (context_id > epoch->max_context_id) {
+    throw invalid_parameter_error("Context ID overflow");
+  }
+
+  auto sender_part = uint64_t(sender_id) << epoch_bits;
+  auto context_part = uint64_t(0);
+  if (epoch->context_bits > 0) {
+    context_part = uint64_t(context_id) << (epoch_bits + epoch->sender_bits);
+  }
+
+  printf("epoch   %016llx\n", epoch_id);
+  printf("sender  %016llx\n", sender_id);
+  printf("context %016llx\n", context_id);
+  printf("epoch   %016llx\n", epoch_index);
+  printf("sender  %016llx\n", sender_part);
+  printf("context %016llx\n", context_part);
+  printf("key_id  %016llx\n", context_part | sender_part | epoch_index);
+
+  return KeyID(context_part | sender_part | epoch_index);
+}
+
+void
+MLSContext::ensure_key(KeyID key_id)
+{
+  // If the required key already exists, we are done
+  const auto epoch_index = key_id & epoch_mask;
+  auto& epoch = epoch_cache.at(epoch_index);
+  if (!epoch) {
+    throw invalid_parameter_error(
+      "Unknown epoch: " + std::to_string(epoch_index));
+  }
+
+
+  if (keys.count(key_id) > 0) {
+    return;
+  }
+
+  // Otherwise, derive a key and implant it
+  const auto sender_id = key_id >> epoch_bits;
+  add_key(key_id, epoch->base_key(suite, sender_id));
+
+  std::cout << "key " << keys.at(key_id).key << std::endl
+          << "salt " << keys.at(key_id).salt << std::endl
+          << std::endl;
+  return;
+}
+
+SFrame::KeyAndSalt&
 MLSContext::get_state(KeyID key_id)
 {
   const auto epoch_index = EpochID(key_id & epoch_mask);
@@ -297,6 +435,5 @@ MLSContext::get_state(KeyID key_id)
 
   return epoch->get(suite, sender_id);
 }
-#endif // 0
 
 } // namespace sframe

--- a/test/sframe.cpp
+++ b/test/sframe.cpp
@@ -181,7 +181,6 @@ TEST_CASE("SFrame Round-Trip")
   }
 }
 
-#if 0
 TEST_CASE("MLS Known-Answer")
 {
   ensure_fips_if_required();
@@ -301,7 +300,6 @@ TEST_CASE("MLS Known-Answer")
       for (size_t j = 0; j < tc.epochs[i].size(); j++) {
         auto encrypted =
           ctx.protect(epoch_ids[i], sender_ids[j], ct_out, plaintext);
-        std::cout << tc.epochs[i][j] << " " << to_bytes(encrypted) << std::endl;
         CHECK(tc.epochs[i][j] == to_bytes(encrypted));
 
         auto decrypted = ctx.unprotect(pt_out, tc.epochs[i][j]);
@@ -346,8 +344,6 @@ TEST_CASE("MLS Round-Trip")
           member_a.protect(epoch_id, sender_id_a, ct_out, plaintext);
         auto decrypted_ab = member_b.unprotect(pt_out, encrypted_ab);
         CHECK(plaintext == to_bytes(decrypted_ab));
-
-        std::cout << encrypted_ab << std::endl;
 
         auto encrypted_ba =
           member_b.protect(epoch_id, sender_id_b, ct_out, plaintext);
@@ -692,7 +688,6 @@ TEST_CASE("MLS Round-Trip with context")
           to_bytes(member_b.unprotect(pt_out, encrypted_ab_1));
         CHECK(plaintext == decrypted_ab_1);
 
-        std::cout << encrypted_ab_0 << " " << encrypted_ab_1 << std::endl;
         CHECK(to_bytes(encrypted_ab_0) != to_bytes(encrypted_ab_1));
 
         auto encrypted_ba =
@@ -753,5 +748,3 @@ TEST_CASE("MLS Failure after Purge")
   const auto dec_ab_2 = member_b.unprotect(pt_out, enc_ab_2);
   CHECK(plaintext == to_bytes(dec_ab_2));
 }
-
-#endif // 0

--- a/test/sframe.cpp
+++ b/test/sframe.cpp
@@ -181,6 +181,7 @@ TEST_CASE("SFrame Round-Trip")
   }
 }
 
+#if 0
 TEST_CASE("MLS Known-Answer")
 {
   ensure_fips_if_required();
@@ -752,3 +753,5 @@ TEST_CASE("MLS Failure after Purge")
   const auto dec_ab_2 = member_b.unprotect(pt_out, enc_ab_2);
   CHECK(plaintext == to_bytes(dec_ab_2));
 }
+
+#endif // 0


### PR DESCRIPTION
This PR makes a few restructurings to clean up the structure of the library:

* The class hierarchy is now stricter.  Instead of `SFrame -> {Context, MLSContext}`, we have:
    * `ContextBase` - Core protect/unprotect functionality, irrespective of header encoding
        * `ContextBase::KeyState` loses its `counter` member and becomes `KeyAndSalt`
    * `Context: protected ContextBase` - Also tracks counters, encodes/decodes header
    * `MLSContext: protected Context` - Also derives per-sender keys from MLS secrets
         * `MLSContext::EpochKeys` no longer stores keys/counters
         * Instead, we use the storage in `ContextBase` and `Context` 
* The `Header` class is restructured so that it owns an encoded representation of the header
    * When constructing from kid+ctr, the values are encoded
    * When constructing from an encoded value, the encoded form is copied in and values are parsed 