### PR TITLE
Remove the need for an allocator

### DIFF
--- a/include/sframe/sframe.h
+++ b/include/sframe/sframe.h
@@ -46,6 +46,9 @@ enum class CipherSuite : uint16_t
 
 constexpr size_t max_overhead = 17 + 16;
 
+template<size_t N>
+using byte_array = std::array<uint8_t, N>;
+
 using bytes = std::vector<uint8_t>;
 using input_bytes = gsl::span<const uint8_t>;
 using output_bytes = gsl::span<uint8_t>;
@@ -72,7 +75,7 @@ private:
   static constexpr size_t min_size = 1;
   static constexpr size_t max_size = 1 + 8 + 8;
 
-  std::array<uint8_t, max_size> buffer;
+  byte_array<max_size> buffer;
 
   Header(KeyID key_id_in,
          Counter counter_in,

--- a/include/sframe/sframe.h
+++ b/include/sframe/sframe.h
@@ -43,12 +43,13 @@ enum class CipherSuite : uint16_t
 constexpr size_t max_overhead = 17 + 16;
 
 template<typename T, size_t N>
-class vector {
-  private:
+class vector
+{
+private:
   std::array<T, N> _data;
   size_t _size;
 
-  public:
+public:
   constexpr vector()
     : _size(N)
   {
@@ -83,17 +84,20 @@ class vector {
   auto end() { return _data.end() + _size; }
 
   auto size() const { return _size; }
-  void resize(size_t size) {
+  void resize(size_t size)
+  {
     assert(size <= N);
     _size = size;
   }
 
-  void push(T&& item) {
+  void push(T&& item)
+  {
     resize(_size + 1);
     _data.at(_size - 1) = item;
   }
 
-  void append(gsl::span<const T> content) {
+  void append(gsl::span<const T> content)
+  {
     const auto original_size = _size;
     resize(_size + content.size());
     std::copy(content.begin(), content.end(), _data.begin() + original_size);
@@ -107,11 +111,14 @@ class vector {
 };
 
 template<typename K, typename V, size_t N>
-class map : private vector<std::optional<std::pair<K, V>>, N> {
-  public:
+class map : private vector<std::optional<std::pair<K, V>>, N>
+{
+public:
   template<class... Args>
-  void emplace(Args&&... args) {
-    const auto pos = std::find_if(this->begin(), this->end(), [&](const auto& pair) { return !pair; });
+  void emplace(Args&&... args)
+  {
+    const auto pos = std::find_if(
+      this->begin(), this->end(), [&](const auto& pair) { return !pair; });
     if (pos == this->end()) {
       throw std::out_of_range("map out of space");
     }
@@ -119,19 +126,24 @@ class map : private vector<std::optional<std::pair<K, V>>, N> {
     pos->emplace(args...);
   }
 
-  auto find(const K& key) const {
-    return std::find_if(this->begin(), this->end(), [&](const auto& pair) { return pair && pair.value().first == key; });
+  auto find(const K& key) const
+  {
+    return std::find_if(this->begin(), this->end(), [&](const auto& pair) {
+      return pair && pair.value().first == key;
+    });
   }
 
-  auto find(const K& key) {
-    return std::find_if(this->begin(), this->end(), [&](const auto& pair) { return pair && pair.value().first == key; });
+  auto find(const K& key)
+  {
+    return std::find_if(this->begin(), this->end(), [&](const auto& pair) {
+      return pair && pair.value().first == key;
+    });
   }
 
-  bool contains(const K& key) const {
-    return find(key) != this->end();
-  }
+  bool contains(const K& key) const { return find(key) != this->end(); }
 
-  const V& at(const K& key) const {
+  const V& at(const K& key) const
+  {
     const auto pos = find(key);
     if (pos == this->end()) {
       throw std::out_of_range("map key not found");
@@ -140,7 +152,8 @@ class map : private vector<std::optional<std::pair<K, V>>, N> {
     return pos->value().second;
   }
 
-  V& at(const K& key) {
+  V& at(const K& key)
+  {
     auto pos = find(key);
     if (pos == this->end()) {
       throw std::out_of_range("map key not found");
@@ -150,7 +163,8 @@ class map : private vector<std::optional<std::pair<K, V>>, N> {
   }
 
   template<typename F>
-  void erase_if_key(F&& f) {
+  void erase_if_key(F&& f)
+  {
     const auto to_erase = [&f](const auto& maybe_pair) {
       return maybe_pair && f(maybe_pair.value().first);
     };
@@ -192,9 +206,7 @@ private:
 
   owned_bytes<max_size> _encoded;
 
-  Header(KeyID key_id_in,
-         Counter counter_in,
-         input_bytes encoded_in);
+  Header(KeyID key_id_in, Counter counter_in, input_bytes encoded_in);
 };
 
 struct KeyAndSalt
@@ -305,7 +317,8 @@ private:
               input_bytes sframe_epoch_secret_in,
               size_t epoch_bits,
               size_t sender_bits_in);
-    owned_bytes<max_secret_size> base_key(CipherSuite suite, SenderID sender_id) const;
+    owned_bytes<max_secret_size> base_key(CipherSuite suite,
+                                          SenderID sender_id) const;
   };
 
   void purge_epoch(EpochID epoch_id);

--- a/src/crypto.cpp
+++ b/src/crypto.cpp
@@ -178,10 +178,7 @@ hkdf_extract(CipherSuite suite, input_bytes salt, input_bytes ikm)
 //
 //   HMAC(Secret, Label || 0x01)
 HMAC::Output
-hkdf_expand(CipherSuite suite,
-            input_bytes prk,
-            input_bytes info,
-            size_t size)
+hkdf_expand(CipherSuite suite, input_bytes prk, input_bytes info, size_t size)
 {
   // Ensure that we need only one hash invocation
   if (size > cipher_digest_size(suite)) {

--- a/src/crypto.cpp
+++ b/src/crypto.cpp
@@ -119,7 +119,6 @@ HMAC::HMAC(CipherSuite suite, input_bytes key)
   : ctx(HMAC_CTX_new(), HMAC_CTX_free)
 {
   const auto type = openssl_digest_type(suite);
-  auto ctx = scoped_hmac_ctx(HMAC_CTX_new(), HMAC_CTX_free);
 
   // Some FIPS-enabled libraries are overly conservative in their interpretation
   // of NIST SP 800-131A, which requires HMAC keys to be at least 112 bits long.
@@ -189,7 +188,7 @@ hkdf_expand(CipherSuite suite,
     throw invalid_parameter_error("Size too big for hkdf_expand");
   }
 
-  static constexpr auto counter = std::array<uint8_t, 1>{ 0x01 };
+  static const auto counter = owned_bytes<1>{ 0x01 };
 
   auto h = HMAC(suite, prk);
   h.write(info);
@@ -221,7 +220,7 @@ ctr_crypt(CipherSuite suite,
   }
 
   static auto padded_nonce =
-    std::array<uint8_t, 16>{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
+    owned_bytes<16>{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
   std::copy(nonce.begin(), nonce.end(), padded_nonce.begin());
 
   auto cipher = openssl_cipher(suite);

--- a/src/crypto.h
+++ b/src/crypto.h
@@ -3,9 +3,6 @@
 #include <openssl/hmac.h>
 #include <sframe/sframe.h>
 
-#include <array>
-#include <cassert>
-
 namespace sframe {
 
 ///

--- a/src/crypto.h
+++ b/src/crypto.h
@@ -31,35 +31,6 @@ cipher_nonce_size(CipherSuite suite);
 /// HMAC and HKDF
 ///
 
-template<size_t N>
-struct owned_bytes {
-  owned_bytes()
-    : _size(N)
-  {
-    std::fill(_data.begin(), _data.end(), 0);
-  }
-
-  uint8_t* data() { return _data.data(); }
-  auto begin() { return _data.begin(); }
-
-  size_t size() const { return _size; }
-  void resize(size_t size) {
-    assert(size < N);
-    _size = size;
-  }
-
-  // TODO(RLB) Delete this once allocations are not needed downstream
-  explicit operator bytes() const { return bytes(_data.begin(), _data.end()); }
-
-  operator input_bytes() const { return input_bytes(_data).first(_size); }
-  operator output_bytes() { return output_bytes(_data).first(_size); }
-
-  private:
-  std::array<uint8_t, N> _data;
-  size_t _size;
-};
-
-
 struct HMAC
 {
   using Output = owned_bytes<EVP_MAX_MD_SIZE>;

--- a/src/crypto.h
+++ b/src/crypto.h
@@ -36,7 +36,7 @@ struct HMAC
   void write(input_bytes data);
   Output digest();
 
-  private:
+private:
   scoped_hmac_ctx ctx;
 };
 
@@ -44,10 +44,7 @@ HMAC::Output
 hkdf_extract(CipherSuite suite, input_bytes salt, input_bytes ikm);
 
 HMAC::Output
-hkdf_expand(CipherSuite suite,
-            input_bytes prk,
-            input_bytes info,
-            size_t size);
+hkdf_expand(CipherSuite suite, input_bytes prk, input_bytes info, size_t size);
 
 ///
 /// AEAD Algorithms

--- a/src/header.cpp
+++ b/src/header.cpp
@@ -156,13 +156,12 @@ Header::parse(input_bytes buffer)
   return Header(key_id, counter, encoded);
 }
 
-Header::Header(KeyID key_id_in,
-               Counter counter_in,
-               input_bytes encoded_in)
+Header::Header(KeyID key_id_in, Counter counter_in, input_bytes encoded_in)
   : key_id(key_id_in)
   , counter(counter_in)
   , _encoded(encoded_in)
-{}
+{
+}
 
 #if 0
 std::tuple<Header, input_bytes>

--- a/src/sframe.cpp
+++ b/src/sframe.cpp
@@ -48,15 +48,15 @@ ContextBase::ContextBase(CipherSuite suite_in)
 ContextBase::~ContextBase() = default;
 
 void
-ContextBase::add_key(KeyID key_id, const bytes& base_key)
+ContextBase::add_key(KeyID key_id, input_bytes base_key)
 {
   keys.emplace(key_id, KeyAndSalt::from_base_key(suite, base_key));
 }
 
-static bytes
-form_nonce(Counter ctr, const bytes& salt)
+static owned_bytes<KeyAndSalt::max_salt_size>
+form_nonce(Counter ctr, input_bytes salt)
 {
-  auto nonce = salt;
+  auto nonce = owned_bytes<KeyAndSalt::max_salt_size>(salt);
   for (size_t i = 0; i < sizeof(ctr); i++) {
     nonce[nonce.size() - i - 1] ^= uint8_t(ctr >> (8 * i));
   }
@@ -98,42 +98,42 @@ ContextBase::unprotect(const Header& header,
   return open(suite, key_and_salt.key, nonce, plaintext, aad, ciphertext);
 }
 
-static const bytes sframe_label{
+static const owned_bytes<8> sframe_label{
   0x53, 0x46, 0x72, 0x61, 0x6d, 0x65, 0x31, 0x30 // "ContextBase10"
 };
-static const bytes sframe_key_label{ 0x6b, 0x65, 0x79 };        // "key"
-static const bytes sframe_salt_label{ 0x73, 0x61, 0x6c, 0x74 }; // "salt"
+static const owned_bytes<3> sframe_key_label{ 0x6b, 0x65, 0x79 };        // "key"
+static const owned_bytes<4> sframe_salt_label{ 0x73, 0x61, 0x6c, 0x74 }; // "salt"
 
-static const bytes sframe_ctr_label{
+static const owned_bytes<20> sframe_ctr_label{
   // "ContextBase10 AES CM AEAD"
   0x53, 0x46, 0x72, 0x61, 0x6d, 0x65, 0x31, 0x30, 0x20, 0x41,
   0x45, 0x53, 0x20, 0x43, 0x4d, 0x20, 0x41, 0x45, 0x41, 0x44,
 };
-static const bytes sframe_enc_label{ 0x65, 0x6e, 0x63 };        // "enc"
-static const bytes sframe_auth_label{ 0x61, 0x75, 0x74, 0x68 }; // "auth"
+static const owned_bytes<3> sframe_enc_label{ 0x65, 0x6e, 0x63 };        // "enc"
+static const owned_bytes<4> sframe_auth_label{ 0x61, 0x75, 0x74, 0x68 }; // "auth"
 
-ContextBase::KeyAndSalt
-ContextBase::KeyAndSalt::from_base_key(CipherSuite suite, const bytes& base_key)
+KeyAndSalt
+KeyAndSalt::from_base_key(CipherSuite suite, input_bytes base_key)
 {
   auto key_size = cipher_key_size(suite);
   auto nonce_size = cipher_nonce_size(suite);
-  auto hash_size = cipher_digest_size(suite);
 
   auto secret = hkdf_extract(suite, sframe_label, base_key);
-  auto key = bytes(hkdf_expand(suite, secret, sframe_key_label, key_size));
-  auto salt = bytes(hkdf_expand(suite, secret, sframe_salt_label, nonce_size));
+  auto key = hkdf_expand(suite, secret, sframe_key_label, key_size);
+  auto salt = hkdf_expand(suite, secret, sframe_salt_label, nonce_size);
 
   // If using CTR+HMAC, set key = enc_key || auth_key
   if (suite == CipherSuite::AES_CM_128_HMAC_SHA256_4 ||
       suite == CipherSuite::AES_CM_128_HMAC_SHA256_8) {
     secret = hkdf_extract(suite, sframe_ctr_label, key);
 
-    auto main_key = key;
-    auto enc_key = bytes(hkdf_expand(suite, secret, sframe_enc_label, key_size));
-    auto auth_key = bytes(hkdf_expand(suite, secret, sframe_auth_label, hash_size));
+    auto enc_key = hkdf_expand(suite, secret, sframe_enc_label, key_size);
+
+    auto hash_size = cipher_digest_size(suite);
+    auto auth_key = hkdf_expand(suite, secret, sframe_auth_label, hash_size);
 
     key = enc_key;
-    key.insert(key.end(), auth_key.begin(), auth_key.end());
+    key.append(auth_key);
   }
 
   return KeyAndSalt{ key, salt, 0 };
@@ -151,7 +151,7 @@ Context::Context(CipherSuite suite_in)
 Context::~Context() = default;
 
 void
-Context::add_key(KeyID key_id, const bytes& base_key)
+Context::add_key(KeyID key_id, input_bytes base_key)
 {
   ContextBase::add_key(key_id, base_key);
   counters.emplace(key_id, 0);
@@ -200,14 +200,14 @@ MLSContext::MLSContext(CipherSuite suite_in, size_t epoch_bits_in)
 }
 
 void
-MLSContext::add_epoch(EpochID epoch_id, const bytes& sframe_epoch_secret)
+MLSContext::add_epoch(EpochID epoch_id, input_bytes sframe_epoch_secret)
 {
   add_epoch(epoch_id, sframe_epoch_secret, 0);
 }
 
 void
 MLSContext::add_epoch(EpochID epoch_id,
-                      const bytes& sframe_epoch_secret,
+                      input_bytes sframe_epoch_secret,
                       size_t sender_bits)
 {
   auto epoch_index = epoch_id & epoch_mask;
@@ -264,11 +264,11 @@ MLSContext::unprotect(output_bytes plaintext, input_bytes ciphertext)
 }
 
 MLSContext::EpochKeys::EpochKeys(MLSContext::EpochID full_epoch_in,
-                                 bytes sframe_epoch_secret_in,
+                                 input_bytes sframe_epoch_secret_in,
                                  size_t epoch_bits,
                                  size_t sender_bits_in)
   : full_epoch(full_epoch_in)
-  , sframe_epoch_secret(std::move(sframe_epoch_secret_in))
+  , sframe_epoch_secret(sframe_epoch_secret_in)
   , sender_bits(sender_bits_in)
 {
   static constexpr uint64_t one = 1;
@@ -290,16 +290,16 @@ MLSContext::EpochKeys::EpochKeys(MLSContext::EpochID full_epoch_in,
   max_context_id = (one << (context_bits + 1)) - 1;
 }
 
-bytes
+owned_bytes<MLSContext::EpochKeys::max_secret_size>
 MLSContext::EpochKeys::base_key(CipherSuite ciphersuite,
                                 SenderID sender_id) const
 {
-  auto hash_size = cipher_digest_size(ciphersuite);
-  auto enc_sender_id = bytes(8);
+  const auto hash_size = cipher_digest_size(ciphersuite);
+  auto enc_sender_id = owned_bytes<8>();
   encode_uint(sender_id, enc_sender_id);
 
-  return bytes(hkdf_expand(
-    ciphersuite, sframe_epoch_secret, enc_sender_id, hash_size));
+  return hkdf_expand(
+    ciphersuite, sframe_epoch_secret, enc_sender_id, hash_size);
 }
 
 void

--- a/src/sframe.cpp
+++ b/src/sframe.cpp
@@ -81,25 +81,18 @@ ContextBase::unprotect(const Header& header,
   return open(suite, key_and_salt.key, nonce, plaintext, aad, ciphertext);
 }
 
-static const owned_bytes<8> sframe_label{
-  0x53, 0x46, 0x72, 0x61, 0x6d, 0x65, 0x31, 0x30 // "ContextBase10"
-};
-static const owned_bytes<3> sframe_key_label{ 0x6b, 0x65, 0x79 }; // "key"
-static const owned_bytes<4> sframe_salt_label{ 0x73,
-                                               0x61,
-                                               0x6c,
-                                               0x74 }; // "salt"
+static auto from_ascii(const char* str) {
+  const auto ptr = reinterpret_cast<const uint8_t*>(str);
+  return input_bytes(ptr, strlen(str));
+}
 
-static const owned_bytes<20> sframe_ctr_label{
-  // "ContextBase10 AES CM AEAD"
-  0x53, 0x46, 0x72, 0x61, 0x6d, 0x65, 0x31, 0x30, 0x20, 0x41,
-  0x45, 0x53, 0x20, 0x43, 0x4d, 0x20, 0x41, 0x45, 0x41, 0x44,
-};
-static const owned_bytes<3> sframe_enc_label{ 0x65, 0x6e, 0x63 }; // "enc"
-static const owned_bytes<4> sframe_auth_label{ 0x61,
-                                               0x75,
-                                               0x74,
-                                               0x68 }; // "auth"
+static const auto sframe_label = from_ascii("ContextBase10");
+static const auto sframe_key_label = from_ascii("key");
+static const auto sframe_salt_label = from_ascii("salt");
+
+static const auto sframe_ctr_label = from_ascii("ContextBase10 AES CM AEAD");
+static const auto sframe_enc_label = from_ascii("enc");
+static const auto sframe_auth_label = from_ascii("auth");
 
 KeyAndSalt
 KeyAndSalt::from_base_key(CipherSuite suite, input_bytes base_key)

--- a/src/sframe.cpp
+++ b/src/sframe.cpp
@@ -120,8 +120,8 @@ ContextBase::KeyAndSalt::from_base_key(CipherSuite suite, const bytes& base_key)
   auto hash_size = cipher_digest_size(suite);
 
   auto secret = hkdf_extract(suite, sframe_label, base_key);
-  auto key = hkdf_expand(suite, secret, sframe_key_label, key_size);
-  auto salt = hkdf_expand(suite, secret, sframe_salt_label, nonce_size);
+  auto key = bytes(hkdf_expand(suite, secret, sframe_key_label, key_size));
+  auto salt = bytes(hkdf_expand(suite, secret, sframe_salt_label, nonce_size));
 
   // If using CTR+HMAC, set key = enc_key || auth_key
   if (suite == CipherSuite::AES_CM_128_HMAC_SHA256_4 ||
@@ -129,8 +129,8 @@ ContextBase::KeyAndSalt::from_base_key(CipherSuite suite, const bytes& base_key)
     secret = hkdf_extract(suite, sframe_ctr_label, key);
 
     auto main_key = key;
-    auto enc_key = hkdf_expand(suite, secret, sframe_enc_label, key_size);
-    auto auth_key = hkdf_expand(suite, secret, sframe_auth_label, hash_size);
+    auto enc_key = bytes(hkdf_expand(suite, secret, sframe_enc_label, key_size));
+    auto auth_key = bytes(hkdf_expand(suite, secret, sframe_auth_label, hash_size));
 
     key = enc_key;
     key.insert(key.end(), auth_key.begin(), auth_key.end());
@@ -298,8 +298,8 @@ MLSContext::EpochKeys::base_key(CipherSuite ciphersuite,
   auto enc_sender_id = bytes(8);
   encode_uint(sender_id, enc_sender_id);
 
-  return hkdf_expand(
-    ciphersuite, sframe_epoch_secret, enc_sender_id, hash_size);
+  return bytes(hkdf_expand(
+    ciphersuite, sframe_epoch_secret, enc_sender_id, hash_size));
 }
 
 void

--- a/src/sframe.cpp
+++ b/src/sframe.cpp
@@ -180,7 +180,7 @@ output_bytes
 Context::unprotect(output_bytes plaintext, input_bytes ciphertext)
 {
   const auto header = Header::parse(ciphertext);
-  const auto inner_ciphertext = ciphertext.subspan(header.size);
+  const auto inner_ciphertext = ciphertext.subspan(header.size());
   return ContextBase::unprotect(header, plaintext, inner_ciphertext);
 }
 
@@ -257,7 +257,7 @@ output_bytes
 MLSContext::unprotect(output_bytes plaintext, input_bytes ciphertext)
 {
   const auto header = Header::parse(ciphertext);
-  const auto inner_ciphertext = ciphertext.subspan(header.size);
+  const auto inner_ciphertext = ciphertext.subspan(header.size());
 
   ensure_key(header.key_id);
   return ContextBase::unprotect(header, plaintext, inner_ciphertext);

--- a/src/sframe.cpp
+++ b/src/sframe.cpp
@@ -84,16 +84,22 @@ ContextBase::unprotect(const Header& header,
 static const owned_bytes<8> sframe_label{
   0x53, 0x46, 0x72, 0x61, 0x6d, 0x65, 0x31, 0x30 // "ContextBase10"
 };
-static const owned_bytes<3> sframe_key_label{ 0x6b, 0x65, 0x79 };        // "key"
-static const owned_bytes<4> sframe_salt_label{ 0x73, 0x61, 0x6c, 0x74 }; // "salt"
+static const owned_bytes<3> sframe_key_label{ 0x6b, 0x65, 0x79 }; // "key"
+static const owned_bytes<4> sframe_salt_label{ 0x73,
+                                               0x61,
+                                               0x6c,
+                                               0x74 }; // "salt"
 
 static const owned_bytes<20> sframe_ctr_label{
   // "ContextBase10 AES CM AEAD"
   0x53, 0x46, 0x72, 0x61, 0x6d, 0x65, 0x31, 0x30, 0x20, 0x41,
   0x45, 0x53, 0x20, 0x43, 0x4d, 0x20, 0x41, 0x45, 0x41, 0x44,
 };
-static const owned_bytes<3> sframe_enc_label{ 0x65, 0x6e, 0x63 };        // "enc"
-static const owned_bytes<4> sframe_auth_label{ 0x61, 0x75, 0x74, 0x68 }; // "auth"
+static const owned_bytes<3> sframe_enc_label{ 0x65, 0x6e, 0x63 }; // "enc"
+static const owned_bytes<4> sframe_auth_label{ 0x61,
+                                               0x75,
+                                               0x74,
+                                               0x68 }; // "auth"
 
 KeyAndSalt
 KeyAndSalt::from_base_key(CipherSuite suite, input_bytes base_key)
@@ -286,9 +292,8 @@ MLSContext::purge_epoch(EpochID epoch_id)
 {
   const auto drop_bits = epoch_id & epoch_bits;
 
-  keys.erase_if_key([&](const auto& epoch) {
-      return (epoch & epoch_bits) == drop_bits;
-  });
+  keys.erase_if_key(
+    [&](const auto& epoch) { return (epoch & epoch_bits) == drop_bits; });
 }
 
 KeyID

--- a/test/header.cpp
+++ b/test/header.cpp
@@ -3,36 +3,12 @@
 #include <openssl/err.h>
 #include <sframe/sframe.h>
 
-#include <iostream>
+#include "common.h"
+
 #include <map>       // for map
 #include <stdexcept> // for invalid_argument
-#include <string>    // for basic_string, operator==
 
 using namespace sframe;
-
-static bytes
-from_hex(const std::string& hex)
-{
-  if (hex.length() % 2 == 1) {
-    throw std::invalid_argument("Odd-length hex string");
-  }
-
-  auto len = int(hex.length() / 2);
-  auto out = bytes(len);
-  for (int i = 0; i < len; i += 1) {
-    auto byte = hex.substr(2 * i, 2);
-    out[i] = static_cast<uint8_t>(strtol(byte.c_str(), nullptr, 16));
-  }
-
-  return out;
-}
-
-template<typename T>
-bytes
-to_bytes(const T& range)
-{
-  return bytes(range.begin(), range.end());
-}
 
 TEST_CASE("Header Known-Answer")
 {

--- a/test/header.cpp
+++ b/test/header.cpp
@@ -63,7 +63,7 @@ TEST_CASE("Header Known-Answer")
     const auto decoded = Header::parse(tc.encoding);
     REQUIRE(decoded.key_id == tc.key_id);
     REQUIRE(decoded.counter == tc.counter);
-    REQUIRE(decoded.size == tc.encoding.size());
+    REQUIRE(decoded.size() == tc.encoding.size());
 
     // Encode
     const auto to_encode = Header{ tc.key_id, tc.counter };

--- a/test/sframe.cpp
+++ b/test/sframe.cpp
@@ -3,6 +3,8 @@
 #include <openssl/err.h>
 #include <sframe/sframe.h>
 
+#include "common.h"
+
 #include <iostream>
 #include <map>       // for map
 #include <stdexcept> // for invalid_argument
@@ -17,30 +19,6 @@ ensure_fips_if_required()
   if (require && FIPS_mode() == 0) {
     REQUIRE(FIPS_mode_set(1) == 1);
   }
-}
-
-static bytes
-from_hex(const std::string& hex)
-{
-  if (hex.length() % 2 == 1) {
-    throw std::invalid_argument("Odd-length hex string");
-  }
-
-  auto len = int(hex.length() / 2);
-  auto out = bytes(len);
-  for (int i = 0; i < len; i += 1) {
-    auto byte = hex.substr(2 * i, 2);
-    out[i] = static_cast<uint8_t>(strtol(byte.c_str(), nullptr, 16));
-  }
-
-  return out;
-}
-
-template<typename T>
-bytes
-to_bytes(const T& range)
-{
-  return bytes(range.begin(), range.end());
 }
 
 #if 0 // XXX(RLB) Disabled for now; to be replaced by test vectors

--- a/test/sframe.cpp
+++ b/test/sframe.cpp
@@ -161,8 +161,8 @@ TEST_CASE("SFrame Round-Trip")
   }
 }
 
-#if 0 // XXX(RLB) Disabled for now; to be replaced by test vectors or fresh
-      // known-answer tests.
+#if 0  // XXX(RLB) Disabled for now; to be replaced by test vectors or fresh
+       // known-answer tests.
 TEST_CASE("MLS Known-Answer")
 {
   ensure_fips_if_required();

--- a/test/vectors.cpp
+++ b/test/vectors.cpp
@@ -64,7 +64,7 @@ struct HeaderTestVector
     const auto decoded = Header::parse(encoded);
     REQUIRE(decoded.key_id == kid);
     REQUIRE(decoded.counter == ctr);
-    REQUIRE(decoded.size == encoded.data.size());
+    REQUIRE(decoded.size() == encoded.data.size());
     REQUIRE(decoded.encoded() == encoded);
 
     // Encode

--- a/test/vectors.cpp
+++ b/test/vectors.cpp
@@ -10,22 +10,29 @@
 using namespace sframe;
 using nlohmann::json;
 
-struct HexBytes {
+struct HexBytes
+{
   bytes data;
 
   operator input_bytes() const { return data; }
 };
 
 // Seems redundant, but works
-bool operator==(const HexBytes& hex, const input_bytes& other) {
+bool
+operator==(const HexBytes& hex, const input_bytes& other)
+{
   return input_bytes(hex) == other;
 }
 
-bool operator==(const input_bytes& other, const HexBytes& hex) {
+bool
+operator==(const input_bytes& other, const HexBytes& hex)
+{
   return hex == other;
 }
 
-void from_json(const json& j, HexBytes& b) {
+void
+from_json(const json& j, HexBytes& b)
+{
   const auto hex = j.get<std::string>();
 
   if (hex.length() % 2 == 1) {
@@ -40,7 +47,9 @@ void from_json(const json& j, HexBytes& b) {
   }
 }
 
-void to_json(json& /* j */, const HexBytes& /* p */) {
+void
+to_json(json& /* j */, const HexBytes& /* p */)
+{
   // Included just so that macros work
 }
 
@@ -52,7 +61,8 @@ struct HeaderTestVector
 
   NLOHMANN_DEFINE_TYPE_INTRUSIVE(HeaderTestVector, kid, ctr, encoded)
 
-  void verify() const {
+  void verify() const
+  {
     // Decode
     const auto decoded = Header::parse(encoded);
     REQUIRE(decoded.key_id == kid);
@@ -87,7 +97,8 @@ struct AesCtrHmacTestVector
                                  pt,
                                  ct)
 
-  void verify() const {
+  void verify() const
+  {
 #if 0 // TODO(RLB) Re-enable after updating crypto routines to match the spec
     // Seal
     auto ciphertext = bytes(ct.data.size());
@@ -131,7 +142,8 @@ struct SFrameTestVector
                                  pt,
                                  ct)
 
-  void verify() const {
+  void verify() const
+  {
     // TODO(RLB)
   }
 };

--- a/test/vectors.cpp
+++ b/test/vectors.cpp
@@ -5,6 +5,8 @@
 
 #include <crypto.h>
 
+#include "common.h"
+
 using namespace sframe;
 using nlohmann::json;
 
@@ -40,15 +42,6 @@ void from_json(const json& j, HexBytes& b) {
 
 void to_json(json& /* j */, const HexBytes& /* p */) {
   // Included just so that macros work
-}
-
-std::string to_hex(const input_bytes data) {
-  std::stringstream hex(std::ios_base::out);
-  hex.flags(std::ios::hex);
-  for (const auto& byte : data) {
-    hex << std::setw(2) << std::setfill('0') << int(byte);
-  }
-  return hex.str();
 }
 
 struct HeaderTestVector


### PR DESCRIPTION
This PR removes the need for dynamic allocations in this library.  To do this, we have to define `vector` and `map` types that have fixed maximum sizes (as the [heapless crate](https://docs.rs/heapless/latest/heapless/index.html) does for Rust).  For the most part, this is not a salient restriction, because things like keys and nonces have small, known, fixed sizes.

The main restriction this imposes is that the key/counter stores inside ContextBase, Context, and MLSContext now have fixed maximum sizes.  Fixed at compile time, moreover.  We may want to make this more flexible, e.g., by having the caller pass in a pointer to a storage class.