### PR TITLE
Pass SFrame test vectors

### DIFF
--- a/include/sframe/sframe.h
+++ b/include/sframe/sframe.h
@@ -34,10 +34,11 @@ struct invalid_parameter_error : std::runtime_error
 
 enum class CipherSuite : uint16_t
 {
-  AES_CM_128_HMAC_SHA256_4 = 1,
-  AES_CM_128_HMAC_SHA256_8 = 2,
-  AES_GCM_128_SHA256 = 3,
-  AES_GCM_256_SHA512 = 4,
+  AES_128_CTR_HMAC_SHA256_80 = 1,
+  AES_128_CTR_HMAC_SHA256_64 = 2,
+  AES_128_CTR_HMAC_SHA256_32 = 3,
+  AES_GCM_128_SHA256 = 4,
+  AES_GCM_256_SHA512 = 5,
 };
 
 constexpr size_t max_overhead = 17 + 16;

--- a/include/sframe/sframe.h
+++ b/include/sframe/sframe.h
@@ -45,9 +45,6 @@ constexpr size_t max_overhead = 17 + 16;
 using input_bytes = gsl::span<const uint8_t>;
 using output_bytes = gsl::span<uint8_t>;
 
-std::ostream&
-operator<<(std::ostream& str, const input_bytes data);
-
 using KeyID = uint64_t;
 using Counter = uint64_t;
 

--- a/include/sframe/sframe.h
+++ b/include/sframe/sframe.h
@@ -97,13 +97,6 @@ public:
     _data.at(_size - 1) = item;
   }
 
-  void append(gsl::span<const T> content)
-  {
-    const auto original_size = _size;
-    resize(_size + content.size());
-    std::copy(content.begin(), content.end(), _data.begin() + original_size);
-  }
-
   auto& operator[](size_t i) { return _data.at(i); }
   const auto& operator[](size_t i) const { return _data.at(i); }
 
@@ -212,7 +205,7 @@ private:
 
 struct KeyAndSalt
 {
-  static KeyAndSalt from_base_key(CipherSuite suite, input_bytes base_key);
+  static KeyAndSalt from_base_key(CipherSuite suite, KeyID key_id, input_bytes base_key);
 
   static constexpr size_t max_key_size = 48;
   static constexpr size_t max_salt_size = 12;

--- a/src/crypto.cpp
+++ b/src/crypto.cpp
@@ -93,10 +93,24 @@ cipher_key_size(CipherSuite suite)
     case CipherSuite::AES_128_CTR_HMAC_SHA256_64:
     case CipherSuite::AES_128_CTR_HMAC_SHA256_32:
     case CipherSuite::AES_GCM_128_SHA256:
-      return 16;
+      return 48;
 
     case CipherSuite::AES_GCM_256_SHA512:
       return 32;
+
+    default:
+      throw unsupported_ciphersuite_error();
+  }
+}
+
+size_t
+cipher_enc_key_size(CipherSuite suite)
+{
+  switch (suite) {
+    case CipherSuite::AES_128_CTR_HMAC_SHA256_80:
+    case CipherSuite::AES_128_CTR_HMAC_SHA256_64:
+    case CipherSuite::AES_128_CTR_HMAC_SHA256_32:
+      return 16;
 
     default:
       throw unsupported_ciphersuite_error();
@@ -285,7 +299,7 @@ seal_ctr(CipherSuite suite,
   }
 
   // Split the key into enc and auth subkeys
-  auto enc_key_size = cipher_key_size(suite);
+  auto enc_key_size = cipher_enc_key_size(suite);
   auto enc_key = key.first(enc_key_size);
   auto auth_key = key.subspan(enc_key_size);
 
@@ -398,7 +412,7 @@ open_ctr(CipherSuite suite,
   auto tag = ct.subspan(inner_ct_size, tag_size);
 
   // Split the key into enc and auth subkeys
-  auto enc_key_size = cipher_key_size(suite);
+  auto enc_key_size = cipher_enc_key_size(suite);
   auto enc_key = key.first(enc_key_size);
   auto auth_key = key.subspan(enc_key_size);
 

--- a/src/crypto.cpp
+++ b/src/crypto.cpp
@@ -1,4 +1,5 @@
 #include "crypto.h"
+#include "header.h"
 
 #include <openssl/err.h>
 #include <openssl/evp.h>
@@ -18,8 +19,9 @@ static const EVP_MD*
 openssl_digest_type(CipherSuite suite)
 {
   switch (suite) {
-    case CipherSuite::AES_CM_128_HMAC_SHA256_4:
-    case CipherSuite::AES_CM_128_HMAC_SHA256_8:
+    case CipherSuite::AES_128_CTR_HMAC_SHA256_80:
+    case CipherSuite::AES_128_CTR_HMAC_SHA256_64:
+    case CipherSuite::AES_128_CTR_HMAC_SHA256_32:
     case CipherSuite::AES_GCM_128_SHA256:
       return EVP_sha256();
 
@@ -35,8 +37,9 @@ static const EVP_CIPHER*
 openssl_cipher(CipherSuite suite)
 {
   switch (suite) {
-    case CipherSuite::AES_CM_128_HMAC_SHA256_4:
-    case CipherSuite::AES_CM_128_HMAC_SHA256_8:
+    case CipherSuite::AES_128_CTR_HMAC_SHA256_80:
+    case CipherSuite::AES_128_CTR_HMAC_SHA256_64:
+    case CipherSuite::AES_128_CTR_HMAC_SHA256_32:
       return EVP_aes_128_ctr();
 
     case CipherSuite::AES_GCM_128_SHA256:
@@ -50,15 +53,18 @@ openssl_cipher(CipherSuite suite)
   }
 }
 
-static size_t
-openssl_tag_size(CipherSuite suite)
+size_t
+overhead(CipherSuite suite)
 {
   switch (suite) {
-    case CipherSuite::AES_CM_128_HMAC_SHA256_4:
-      return 4;
+    case CipherSuite::AES_128_CTR_HMAC_SHA256_80:
+      return 10;
 
-    case CipherSuite::AES_CM_128_HMAC_SHA256_8:
+    case CipherSuite::AES_128_CTR_HMAC_SHA256_64:
       return 8;
+
+    case CipherSuite::AES_128_CTR_HMAC_SHA256_32:
+      return 4;
 
     case CipherSuite::AES_GCM_128_SHA256:
     case CipherSuite::AES_GCM_256_SHA512:
@@ -83,8 +89,9 @@ size_t
 cipher_key_size(CipherSuite suite)
 {
   switch (suite) {
-    case CipherSuite::AES_CM_128_HMAC_SHA256_4:
-    case CipherSuite::AES_CM_128_HMAC_SHA256_8:
+    case CipherSuite::AES_128_CTR_HMAC_SHA256_80:
+    case CipherSuite::AES_128_CTR_HMAC_SHA256_64:
+    case CipherSuite::AES_128_CTR_HMAC_SHA256_32:
     case CipherSuite::AES_GCM_128_SHA256:
       return 16;
 
@@ -100,8 +107,9 @@ size_t
 cipher_nonce_size(CipherSuite suite)
 {
   switch (suite) {
-    case CipherSuite::AES_CM_128_HMAC_SHA256_4:
-    case CipherSuite::AES_CM_128_HMAC_SHA256_8:
+    case CipherSuite::AES_128_CTR_HMAC_SHA256_80:
+    case CipherSuite::AES_128_CTR_HMAC_SHA256_64:
+    case CipherSuite::AES_128_CTR_HMAC_SHA256_32:
     case CipherSuite::AES_GCM_128_SHA256:
     case CipherSuite::AES_GCM_256_SHA512:
       return 12;
@@ -200,6 +208,31 @@ hkdf_expand(CipherSuite suite, input_bytes prk, input_bytes info, size_t size)
 /// AEAD Algorithms
 ///
 
+static HMAC::Output
+compute_tag(CipherSuite suite,
+            input_bytes auth_key,
+            input_bytes nonce,
+            input_bytes aad,
+            input_bytes ct,
+            size_t tag_size)
+{
+  auto len_block = owned_bytes<24>();
+  auto len_view = output_bytes(len_block);
+  encode_uint(aad.size(), len_view.first(8));
+  encode_uint(ct.size(), len_view.subspan(8).first(8));
+  encode_uint(tag_size, len_view.subspan(16));
+
+  auto h = HMAC(suite, auth_key);
+  h.write(len_block);
+  h.write(nonce);
+  h.write(aad);
+  h.write(ct);
+
+  auto tag = h.digest();
+  tag.resize(tag_size);
+  return tag;
+}
+
 static void
 ctr_crypt(CipherSuite suite,
           input_bytes key,
@@ -246,26 +279,22 @@ seal_ctr(CipherSuite suite,
          input_bytes aad,
          input_bytes pt)
 {
-  auto tag_size = openssl_tag_size(suite);
+  auto tag_size = overhead(suite);
   if (ct.size() < pt.size() + tag_size) {
     throw buffer_too_small_error("Ciphertext buffer too small");
   }
 
   // Split the key into enc and auth subkeys
-  auto key_span = input_bytes(key);
   auto enc_key_size = cipher_key_size(suite);
-  auto enc_key = key_span.subspan(0, enc_key_size);
-  auto auth_key = key_span.subspan(enc_key_size);
+  auto enc_key = key.first(enc_key_size);
+  auto auth_key = key.subspan(enc_key_size);
 
   // Encrypt with AES-CM
   auto inner_ct = ct.subspan(0, pt.size());
   ctr_crypt(suite, enc_key, nonce, inner_ct, pt);
 
   // Authenticate with truncated HMAC
-  auto hmac = HMAC(suite, auth_key);
-  hmac.write(aad);
-  hmac.write(inner_ct);
-  auto mac = hmac.digest();
+  auto mac = compute_tag(suite, auth_key, nonce, aad, inner_ct, tag_size);
   auto tag = ct.subspan(pt.size(), tag_size);
   std::copy(mac.begin(), mac.begin() + tag_size, tag.begin());
 
@@ -280,7 +309,7 @@ seal_aead(CipherSuite suite,
           input_bytes aad,
           input_bytes pt)
 {
-  auto tag_size = openssl_tag_size(suite);
+  auto tag_size = overhead(suite);
   if (ct.size() < pt.size() + tag_size) {
     throw buffer_too_small_error("Ciphertext buffer too small");
   }
@@ -327,22 +356,6 @@ seal_aead(CipherSuite suite,
   return ct.subspan(0, pt.size() + tag_size);
 }
 
-size_t
-overhead(CipherSuite suite)
-{
-  switch (suite) {
-    case CipherSuite::AES_CM_128_HMAC_SHA256_4:
-      return 4;
-
-    case CipherSuite::AES_CM_128_HMAC_SHA256_8:
-      return 8;
-
-    case CipherSuite::AES_GCM_128_SHA256:
-    case CipherSuite::AES_GCM_256_SHA512:
-      return 16;
-  }
-}
-
 output_bytes
 seal(CipherSuite suite,
      input_bytes key,
@@ -352,8 +365,9 @@ seal(CipherSuite suite,
      input_bytes pt)
 {
   switch (suite) {
-    case CipherSuite::AES_CM_128_HMAC_SHA256_4:
-    case CipherSuite::AES_CM_128_HMAC_SHA256_8: {
+    case CipherSuite::AES_128_CTR_HMAC_SHA256_80:
+    case CipherSuite::AES_128_CTR_HMAC_SHA256_64:
+    case CipherSuite::AES_128_CTR_HMAC_SHA256_32: {
       return seal_ctr(suite, key, nonce, ct, aad, pt);
     }
 
@@ -374,7 +388,7 @@ open_ctr(CipherSuite suite,
          input_bytes aad,
          input_bytes ct)
 {
-  auto tag_size = openssl_tag_size(suite);
+  auto tag_size = overhead(suite);
   if (ct.size() < tag_size) {
     throw buffer_too_small_error("Ciphertext buffer too small");
   }
@@ -384,21 +398,17 @@ open_ctr(CipherSuite suite,
   auto tag = ct.subspan(inner_ct_size, tag_size);
 
   // Split the key into enc and auth subkeys
-  auto key_span = input_bytes(key);
   auto enc_key_size = cipher_key_size(suite);
-  auto enc_key = key_span.subspan(0, enc_key_size);
-  auto auth_key = key_span.subspan(enc_key_size);
+  auto enc_key = key.first(enc_key_size);
+  auto auth_key = key.subspan(enc_key_size);
 
   // Authenticate with truncated HMAC
-  auto hmac = HMAC(suite, auth_key);
-  hmac.write(aad);
-  hmac.write(inner_ct);
-  auto mac = hmac.digest();
+  auto mac = compute_tag(suite, auth_key, nonce, aad, inner_ct, tag_size);
   if (CRYPTO_memcmp(mac.data(), tag.data(), tag.size()) != 0) {
     throw authentication_error();
   }
 
-  // Decrypt with AES-CM
+  // Decrypt with AES-CTR
   ctr_crypt(suite, enc_key, nonce, pt, ct.subspan(0, inner_ct_size));
 
   return pt.subspan(0, inner_ct_size);
@@ -412,7 +422,7 @@ open_aead(CipherSuite suite,
           input_bytes aad,
           input_bytes ct)
 {
-  auto tag_size = openssl_tag_size(suite);
+  auto tag_size = overhead(suite);
   if (ct.size() < tag_size) {
     throw buffer_too_small_error("Ciphertext buffer too small");
   }
@@ -473,8 +483,9 @@ open(CipherSuite suite,
      input_bytes ct)
 {
   switch (suite) {
-    case CipherSuite::AES_CM_128_HMAC_SHA256_4:
-    case CipherSuite::AES_CM_128_HMAC_SHA256_8: {
+    case CipherSuite::AES_128_CTR_HMAC_SHA256_80:
+    case CipherSuite::AES_128_CTR_HMAC_SHA256_64:
+    case CipherSuite::AES_128_CTR_HMAC_SHA256_32: {
       return open_ctr(suite, key, nonce, pt, aad, ct);
     }
 

--- a/src/crypto.cpp
+++ b/src/crypto.cpp
@@ -241,8 +241,8 @@ compute_tag(CipherSuite suite,
   auto len_block = owned_bytes<24>();
   auto len_view = output_bytes(len_block);
   encode_uint(aad.size(), len_view.first(8));
-  encode_uint(ct.size(), len_view.subspan(8).first(8));
-  encode_uint(tag_size, len_view.subspan(16));
+  encode_uint(ct.size(), len_view.first(16).last(8));
+  encode_uint(tag_size, len_view.last(8));
 
   auto h = HMAC(suite, auth_key);
   h.write(len_block);

--- a/src/crypto.h
+++ b/src/crypto.h
@@ -40,10 +40,13 @@ private:
   scoped_hmac_ctx ctx;
 };
 
+
 HMAC::Output
 hkdf_extract(CipherSuite suite, input_bytes salt, input_bytes ikm);
 
-HMAC::Output
+static constexpr size_t max_hkdf_extract_size = 48;
+
+owned_bytes<max_hkdf_extract_size>
 hkdf_expand(CipherSuite suite, input_bytes prk, input_bytes info, size_t size);
 
 ///

--- a/src/crypto.h
+++ b/src/crypto.h
@@ -40,7 +40,6 @@ private:
   scoped_hmac_ctx ctx;
 };
 
-
 HMAC::Output
 hkdf_extract(CipherSuite suite, input_bytes salt, input_bytes ikm);
 

--- a/src/sframe.cpp
+++ b/src/sframe.cpp
@@ -112,8 +112,9 @@ KeyAndSalt::from_base_key(CipherSuite suite, input_bytes base_key)
   auto salt = hkdf_expand(suite, secret, sframe_salt_label, nonce_size);
 
   // If using CTR+HMAC, set key = enc_key || auth_key
-  if (suite == CipherSuite::AES_CM_128_HMAC_SHA256_4 ||
-      suite == CipherSuite::AES_CM_128_HMAC_SHA256_8) {
+  if (suite == CipherSuite::AES_128_CTR_HMAC_SHA256_80 ||
+      suite == CipherSuite::AES_128_CTR_HMAC_SHA256_64 ||
+      suite == CipherSuite::AES_128_CTR_HMAC_SHA256_32) {
     secret = hkdf_extract(suite, sframe_ctr_label, key);
 
     auto enc_key = hkdf_expand(suite, secret, sframe_enc_label, key_size);

--- a/src/sframe.cpp
+++ b/src/sframe.cpp
@@ -99,56 +99,16 @@ static auto from_ascii(const char* str) {
   return input_bytes(ptr, strlen(str));
 }
 
-static const auto sframe_label = from_ascii("ContextBase10");
-static const auto sframe_key_label = from_ascii("key");
-static const auto sframe_salt_label = from_ascii("salt");
-
-static const auto sframe_ctr_label = from_ascii("ContextBase10 AES CM AEAD");
-static const auto sframe_enc_label = from_ascii("enc");
-static const auto sframe_auth_label = from_ascii("auth");
+static const auto base_label = from_ascii("SFrame 1.0 Secret ");
+static const auto key_label = from_ascii("key ");
+static const auto salt_label = from_ascii("salt ");
 
 owned_bytes<32>
 sframe_key_label(CipherSuite suite, KeyID key_id)
 {
-  auto label = owned_bytes<32>{
-    // "SFrame 1.0 Secret key "
-    0x53,
-    0x46,
-    0x72,
-    0x61,
-    0x6d,
-    0x65,
-    0x20,
-    0x31,
-    0x2e,
-    0x30,
-    0x20,
-    0x53,
-    0x65,
-    0x63,
-    0x72,
-    0x65,
-    0x74,
-    0x20,
-    0x6b,
-    0x65,
-    0x79,
-    0x20,
-
-    // Encoded KID
-    0x00,
-    0x00,
-    0x00,
-    0x00,
-    0x00,
-    0x00,
-    0x00,
-    0x00,
-
-    // Encoded CipherSuite
-    0x00,
-    0x00,
-  };
+  auto label = owned_bytes<32>(base_label);
+  label.append(key_label);
+  label.resize(32);
 
   auto label_data = output_bytes(label);
   encode_uint(key_id, label_data.subspan(22).first(8));
@@ -160,51 +120,13 @@ sframe_key_label(CipherSuite suite, KeyID key_id)
 owned_bytes<33>
 sframe_salt_label(CipherSuite suite, KeyID key_id)
 {
-  // TODO
-  auto label = owned_bytes<33>{
-    // "SFrame 1.0 Secret salt "
-    0x53,
-    0x46,
-    0x72,
-    0x61,
-    0x6d,
-    0x65,
-    0x20,
-    0x31,
-    0x2e,
-    0x30,
-    0x20,
-    0x53,
-    0x65,
-    0x63,
-    0x72,
-    0x65,
-    0x74,
-    0x20,
-    0x73,
-    0x61,
-    0x6c,
-    0x74,
-    0x20,
-
-    // Encoded KID
-    0x00,
-    0x00,
-    0x00,
-    0x00,
-    0x00,
-    0x00,
-    0x00,
-    0x00,
-
-    // Encoded CipherSuite
-    0x00,
-    0x00,
-  };
+  auto label = owned_bytes<33>(base_label);
+  label.append(salt_label);
+  label.resize(33);
 
   auto label_data = output_bytes(label);
-  encode_uint(key_id, label_data.subspan(23).first(8));
-  encode_uint(static_cast<uint64_t>(suite), label_data.subspan(31));
+  encode_uint(key_id, label_data.last(10).first(8));
+  encode_uint(static_cast<uint64_t>(suite), label_data.last(2));
 
   return label;
 }

--- a/test/sframe.cpp
+++ b/test/sframe.cpp
@@ -156,8 +156,8 @@ TEST_CASE("SFrame Round-Trip")
     recv.add_key(kid, key);
 
     for (int i = 0; i < rounds; i++) {
-      auto encrypted = to_bytes(send.protect(kid, ct_out, plaintext));
-      auto decrypted = to_bytes(recv.unprotect(pt_out, encrypted));
+      auto encrypted = to_bytes(send.protect(kid, ct_out, plaintext, {}));
+      auto decrypted = to_bytes(recv.unprotect(pt_out, encrypted, {}));
       CHECK(decrypted == plaintext);
     }
   }

--- a/test/sframe.cpp
+++ b/test/sframe.cpp
@@ -129,9 +129,11 @@ TEST_CASE("SFrame Round-Trip")
   const auto kid = KeyID(0x42);
   const auto plaintext = from_hex("00010203");
   const std::map<CipherSuite, bytes> keys{
-    { CipherSuite::AES_CM_128_HMAC_SHA256_4,
+    { CipherSuite::AES_128_CTR_HMAC_SHA256_80,
+      from_hex("000102030405060708090a0b0c0d0e0f") },
+    { CipherSuite::AES_128_CTR_HMAC_SHA256_80,
       from_hex("101112131415161718191a1b1c1d1e1f") },
-    { CipherSuite::AES_CM_128_HMAC_SHA256_8,
+    { CipherSuite::AES_128_CTR_HMAC_SHA256_80,
       from_hex("202122232425262728292a2b2c2d2e2f") },
     { CipherSuite::AES_GCM_128_SHA256,
       from_hex("303132333435363738393a3b3c3d3e3f") },

--- a/test/vectors.cpp
+++ b/test/vectors.cpp
@@ -99,17 +99,20 @@ struct AesCtrHmacTestVector
 
   void verify() const
   {
-#if 0 // TODO(RLB) Re-enable after updating crypto routines to match the spec
     // Seal
     auto ciphertext = bytes(ct.data.size());
     const auto ct_out = seal(cipher_suite, key, nonce, ciphertext, aad, pt);
+
+    const auto act_ct_hex = to_hex(ct_out);
+    const auto exp_ct_hex = to_hex(ct);
+    REQUIRE(act_ct_hex == exp_ct_hex);
+
     REQUIRE(ct_out == ct);
 
     // Open
     auto plaintext = bytes(pt.data.size());
     const auto pt_out = open(cipher_suite, key, nonce, plaintext, aad, ct);
     REQUIRE(pt_out == pt);
-#endif
   }
 };
 

--- a/test/vectors.cpp
+++ b/test/vectors.cpp
@@ -149,11 +149,11 @@ struct SFrameTestVector
     auto ct_data = owned_bytes<128>();
     auto next_ctr = uint64_t(0);
     while (next_ctr < ctr) {
-      send_ctx.protect(kid, ct_data, pt);
+      send_ctx.protect(kid, ct_data, pt, metadata);
       next_ctr += 1;
     }
 
-    const auto ct_out = send_ctx.protect(kid, ct_data, pt);
+    const auto ct_out = send_ctx.protect(kid, ct_data, pt, metadata);
 
     const auto act_ct_hex = to_hex(ct_out);
     const auto exp_ct_hex = to_hex(ct);
@@ -166,7 +166,7 @@ struct SFrameTestVector
     recv_ctx.add_key(kid, base_key);
 
     auto pt_data = owned_bytes<128>();
-    auto pt_out = recv_ctx.unprotect(pt_data, ct);
+    auto pt_out = recv_ctx.unprotect(pt_data, ct, metadata);
     CHECK(pt_out == pt);
   }
 };

--- a/test/vectors.cpp
+++ b/test/vectors.cpp
@@ -157,9 +157,9 @@ struct SFrameTestVector
 
     const auto act_ct_hex = to_hex(ct_out);
     const auto exp_ct_hex = to_hex(ct);
-    REQUIRE(act_ct_hex == exp_ct_hex);
+    CHECK(act_ct_hex == exp_ct_hex);
 
-    REQUIRE(ct_out == ct);
+    CHECK(ct_out == ct);
 
     // Unprotect
     auto recv_ctx = Context(cipher_suite);
@@ -167,7 +167,7 @@ struct SFrameTestVector
 
     auto pt_data = owned_bytes<128>();
     auto pt_out = recv_ctx.unprotect(pt_data, ct);
-    REQUIRE(pt_out == pt);
+    CHECK(pt_out == pt);
   }
 };
 


### PR DESCRIPTION
With this PR, the code passes all of the test vectors in RFC 9605.  A couple of changes were needed:

* Realigning the code point numbers to match the RFC
* Allowing for a metadata input to protect/unprotect
* Updating `hkdf_expand` to support multiple blocks of output (since AES-CTR-HMAC keys are 48 bytes = 1.5 blocks long)
* Aligning the AAD computation for AES-CTR-HMAC with the RFC