### PR TITLE
Refactor for crypto library agility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.10)
 
 project(sframe
   VERSION 0.1
@@ -8,6 +8,11 @@ project(sframe
 option(TESTING    "Build tests" OFF)
 option(CLANG_TIDY "Perform linting with clang-tidy" OFF)
 option(SANITIZERS "Enable sanitizers" OFF)
+
+# Use -DCRYPTO=(OPENSSL_1_1 | OPENSSL_3) to configure crypto
+if(NOT DEFINED CRYPTO)
+  set(CRYPTO "OPENSSL_1_1")
+endif()
 
 ###
 ### Global Config
@@ -49,7 +54,20 @@ endif()
 ###
 
 # External libraries
-find_package(OpenSSL 1.1 REQUIRED)
+if(${CRYPTO} STREQUAL "OPENSSL_1_1")
+  message(STATUS "Configuring with OpenSSL 1.1")
+  find_package(OpenSSL 1.1 EXACT REQUIRED)
+  add_compile_definitions(OPENSSL_1_1)
+  set(CRYPTO_LIB OpenSSL::Crypto)
+elseif(${CRYPTO} STREQUAL "OPENSSL_3")
+  message(STATUS "Configuring with OpenSSL 3")
+  find_package(OpenSSL 3 EXACT REQUIRED)
+  add_compile_definitions(OPENSSL_3)
+  set(CRYPTO_LIB OpenSSL::Crypto)
+else()
+  message(FATAL_ERROR "Please select a crypto back-end (OPENSSL_1_1 or OPENSSL_3) [${CRYPTO}]")
+endif()
+
 
 ###
 ### Library Config
@@ -61,7 +79,7 @@ file(GLOB_RECURSE LIB_HEADERS CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/inc
 file(GLOB_RECURSE LIB_SOURCES CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")
 
 add_library(${LIB_NAME} ${LIB_HEADERS} ${LIB_SOURCES})
-target_link_libraries(${LIB_NAME} PRIVATE OpenSSL::Crypto)
+target_link_libraries(${LIB_NAME} PRIVATE ${CRYPTO_LIB})
 target_include_directories(${LIB_NAME}
   PUBLIC
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,9 @@ ${BUILD_DIR}: CMakeLists.txt test/CMakeLists.txt
 dev: CMakeLists.txt test/CMakeLists.txt
 	cmake -B${BUILD_DIR} -DCMAKE_BUILD_TYPE=Debug -DCLANG_TIDY=ON -DTESTING=ON -DSANITIZERS=ON .
 
+dev3: CMakeLists.txt test/CMakeLists.txt
+	cmake -B${BUILD_DIR} -DCMAKE_BUILD_TYPE=Debug -DCLANG_TIDY=ON -DTESTING=ON -DSANITIZERS=ON -DCRYPTO=OPENSSL_3 .
+
 ${TEST_BIN}: ${LIB} test/*
 	cmake --build ${BUILD_DIR} --target sframe_test
 

--- a/include/sframe/sframe.h
+++ b/include/sframe/sframe.h
@@ -4,9 +4,9 @@
 
 namespace sframe {
 
-struct openssl_error : std::runtime_error
+struct crypto_error : std::runtime_error
 {
-  openssl_error();
+  crypto_error();
 };
 
 struct unsupported_ciphersuite_error : std::runtime_error
@@ -98,6 +98,7 @@ public:
   auto end() { return _data.begin() + _size; }
 
   auto size() const { return _size; }
+  auto capacity() const { return N; }
   void resize(size_t size)
   {
     if (size > N) {

--- a/include/sframe/sframe.h
+++ b/include/sframe/sframe.h
@@ -63,9 +63,9 @@ public:
   }
 
   constexpr vector(size_t size)
-    : _size(size)
   {
     std::fill(_data.begin(), _data.end(), T());
+    resize(size);
   }
 
   constexpr vector(std::initializer_list<uint8_t> content)

--- a/src/crypto.cpp
+++ b/src/crypto.cpp
@@ -6,83 +6,22 @@
 
 namespace sframe {
 
-///
-/// Convert between native identifiers / errors and OpenSSL ones
-///
-
-openssl_error::openssl_error()
-  : std::runtime_error(ERR_error_string(ERR_get_error(), nullptr))
-{
-}
-
-static const EVP_MD*
-openssl_digest_type(CipherSuite suite)
-{
-  switch (suite) {
-    case CipherSuite::AES_128_CTR_HMAC_SHA256_80:
-    case CipherSuite::AES_128_CTR_HMAC_SHA256_64:
-    case CipherSuite::AES_128_CTR_HMAC_SHA256_32:
-    case CipherSuite::AES_GCM_128_SHA256:
-      return EVP_sha256();
-
-    case CipherSuite::AES_GCM_256_SHA512:
-      return EVP_sha512();
-
-    default:
-      throw unsupported_ciphersuite_error();
-  }
-}
-
-static const EVP_CIPHER*
-openssl_cipher(CipherSuite suite)
-{
-  switch (suite) {
-    case CipherSuite::AES_128_CTR_HMAC_SHA256_80:
-    case CipherSuite::AES_128_CTR_HMAC_SHA256_64:
-    case CipherSuite::AES_128_CTR_HMAC_SHA256_32:
-      return EVP_aes_128_ctr();
-
-    case CipherSuite::AES_GCM_128_SHA256:
-      return EVP_aes_128_gcm();
-
-    case CipherSuite::AES_GCM_256_SHA512:
-      return EVP_aes_256_gcm();
-
-    default:
-      throw unsupported_ciphersuite_error();
-  }
-}
-
-size_t
-overhead(CipherSuite suite)
-{
-  switch (suite) {
-    case CipherSuite::AES_128_CTR_HMAC_SHA256_80:
-      return 10;
-
-    case CipherSuite::AES_128_CTR_HMAC_SHA256_64:
-      return 8;
-
-    case CipherSuite::AES_128_CTR_HMAC_SHA256_32:
-      return 4;
-
-    case CipherSuite::AES_GCM_128_SHA256:
-    case CipherSuite::AES_GCM_256_SHA512:
-      return 16;
-
-    default:
-      throw unsupported_ciphersuite_error();
-  }
-}
-
-///
-/// Information about algorithms
-///
-
 size_t
 cipher_digest_size(CipherSuite suite)
 {
-  return EVP_MD_size(openssl_digest_type(suite));
+  switch (suite) {
+    case CipherSuite::AES_128_CTR_HMAC_SHA256_80:
+    case CipherSuite::AES_128_CTR_HMAC_SHA256_64:
+    case CipherSuite::AES_128_CTR_HMAC_SHA256_32:
+    case CipherSuite::AES_GCM_128_SHA256:
+      return 32;
+
+    case CipherSuite::AES_GCM_256_SHA512:
+      return 64;
+
+    default:
+      throw unsupported_ciphersuite_error();
+  }
 }
 
 size_t
@@ -92,8 +31,10 @@ cipher_key_size(CipherSuite suite)
     case CipherSuite::AES_128_CTR_HMAC_SHA256_80:
     case CipherSuite::AES_128_CTR_HMAC_SHA256_64:
     case CipherSuite::AES_128_CTR_HMAC_SHA256_32:
-    case CipherSuite::AES_GCM_128_SHA256:
       return 48;
+
+    case CipherSuite::AES_GCM_128_SHA256:
+      return 16;
 
     case CipherSuite::AES_GCM_256_SHA512:
       return 32;
@@ -133,392 +74,26 @@ cipher_nonce_size(CipherSuite suite)
   }
 }
 
-///
-/// HMAC and HKDF
-///
-
-HMAC::HMAC(CipherSuite suite, input_bytes key)
-  : ctx(HMAC_CTX_new(), HMAC_CTX_free)
-{
-  const auto type = openssl_digest_type(suite);
-
-  // Some FIPS-enabled libraries are overly conservative in their interpretation
-  // of NIST SP 800-131A, which requires HMAC keys to be at least 112 bits long.
-  // That document does not impose that requirement on HKDF, so we disable FIPS
-  // enforcement for purposes of HKDF.
-  //
-  // https://doi.org/10.6028/NIST.SP.800-131Ar2
-  static const auto fips_min_hmac_key_len = 14;
-  auto key_size = static_cast<int>(key.size());
-  if (FIPS_mode() != 0 && key_size < fips_min_hmac_key_len) {
-    HMAC_CTX_set_flags(ctx.get(), EVP_MD_CTX_FLAG_NON_FIPS_ALLOW);
-  }
-
-  // Guard against sending nullptr to HMAC_Init_ex
-  const auto* key_data = key.data();
-  const auto non_null_zero_length_key = uint8_t(0);
-  if (key_data == nullptr) {
-    key_data = &non_null_zero_length_key;
-  }
-
-  if (1 != HMAC_Init_ex(ctx.get(), key_data, key_size, type, nullptr)) {
-    throw openssl_error();
-  }
-}
-
-void
-HMAC::write(input_bytes data)
-{
-  if (1 != HMAC_Update(ctx.get(), data.data(), data.size())) {
-    throw openssl_error();
-  }
-}
-
-HMAC::Output
-HMAC::digest()
-{
-  unsigned int size = int(0);
-  auto md = Output{};
-  if (1 != HMAC_Final(ctx.get(), md.data(), &size)) {
-    throw openssl_error();
-  }
-
-  md.resize(static_cast<size_t>(size));
-  return md;
-}
-
-HMAC::Output
-hkdf_extract(CipherSuite suite, input_bytes salt, input_bytes ikm)
-{
-  auto h = HMAC(suite, salt);
-  h.write(ikm);
-  return h.digest();
-}
-
-owned_bytes<max_hkdf_extract_size>
-hkdf_expand(CipherSuite suite, input_bytes prk, input_bytes info, size_t size)
-{
-  // Ensure that we need only one hash invocation
-  if (size > max_hkdf_extract_size) {
-    throw invalid_parameter_error("Size too big for hkdf_expand");
-  }
-
-  auto out = owned_bytes<max_hkdf_extract_size>(0);
-
-  auto block = HMAC::Output(0);
-  const auto block_size = cipher_digest_size(suite);
-  auto counter = uint8_t(0x01);
-  while (out.size() < size) {
-    // for (auto start = size_t(0); start < out.size(); start += block_size) {
-    auto h = HMAC(suite, prk);
-    h.write(block);
-    h.write(info);
-    h.write(owned_bytes<1>{ counter });
-    block = h.digest();
-
-    const auto remaining = size - out.size();
-    const auto to_write = (remaining < block_size) ? remaining : block_size;
-    out.append(input_bytes(block).first(to_write));
-
-    counter += 1;
-  }
-
-  return out;
-}
-
-///
-/// AEAD Algorithms
-///
-
-static HMAC::Output
-compute_tag(CipherSuite suite,
-            input_bytes auth_key,
-            input_bytes nonce,
-            input_bytes aad,
-            input_bytes ct,
-            size_t tag_size)
-{
-  auto len_block = owned_bytes<24>();
-  auto len_view = output_bytes(len_block);
-  encode_uint(aad.size(), len_view.first(8));
-  encode_uint(ct.size(), len_view.first(16).last(8));
-  encode_uint(tag_size, len_view.last(8));
-
-  auto h = HMAC(suite, auth_key);
-  h.write(len_block);
-  h.write(nonce);
-  h.write(aad);
-  h.write(ct);
-
-  auto tag = h.digest();
-  tag.resize(tag_size);
-  return tag;
-}
-
-static void
-ctr_crypt(CipherSuite suite,
-          input_bytes key,
-          input_bytes nonce,
-          output_bytes out,
-          input_bytes in)
-{
-  if (out.size() != in.size()) {
-    throw buffer_too_small_error("CTR size mismatch");
-  }
-
-  auto ctx = scoped_evp_ctx(EVP_CIPHER_CTX_new(), EVP_CIPHER_CTX_free);
-  if (ctx.get() == nullptr) {
-    throw openssl_error();
-  }
-
-  auto padded_nonce = owned_bytes<16>(0);
-  padded_nonce.append(nonce);
-  padded_nonce.resize(16);
-
-  auto cipher = openssl_cipher(suite);
-  if (1 !=
-      EVP_EncryptInit(ctx.get(), cipher, key.data(), padded_nonce.data())) {
-    throw openssl_error();
-  }
-
-  int outlen = 0;
-  auto in_size_int = static_cast<int>(in.size());
-  if (1 != EVP_EncryptUpdate(
-             ctx.get(), out.data(), &outlen, in.data(), in_size_int)) {
-    throw openssl_error();
-  }
-
-  if (1 != EVP_EncryptFinal(ctx.get(), nullptr, &outlen)) {
-    throw openssl_error();
-  }
-}
-
-static output_bytes
-seal_ctr(CipherSuite suite,
-         input_bytes key,
-         input_bytes nonce,
-         output_bytes ct,
-         input_bytes aad,
-         input_bytes pt)
-{
-  auto tag_size = overhead(suite);
-  if (ct.size() < pt.size() + tag_size) {
-    throw buffer_too_small_error("Ciphertext buffer too small");
-  }
-
-  // Split the key into enc and auth subkeys
-  auto enc_key_size = cipher_enc_key_size(suite);
-  auto enc_key = key.first(enc_key_size);
-  auto auth_key = key.subspan(enc_key_size);
-
-  // Encrypt with AES-CM
-  auto inner_ct = ct.subspan(0, pt.size());
-  ctr_crypt(suite, enc_key, nonce, inner_ct, pt);
-
-  // Authenticate with truncated HMAC
-  auto mac = compute_tag(suite, auth_key, nonce, aad, inner_ct, tag_size);
-  auto tag = ct.subspan(pt.size(), tag_size);
-  std::copy(mac.begin(), mac.begin() + tag_size, tag.begin());
-
-  return ct.subspan(0, pt.size() + tag_size);
-}
-
-static output_bytes
-seal_aead(CipherSuite suite,
-          input_bytes key,
-          input_bytes nonce,
-          output_bytes ct,
-          input_bytes aad,
-          input_bytes pt)
-{
-  auto tag_size = overhead(suite);
-  if (ct.size() < pt.size() + tag_size) {
-    throw buffer_too_small_error("Ciphertext buffer too small");
-  }
-
-  auto ctx = scoped_evp_ctx(EVP_CIPHER_CTX_new(), EVP_CIPHER_CTX_free);
-  if (ctx.get() == nullptr) {
-    throw openssl_error();
-  }
-
-  auto cipher = openssl_cipher(suite);
-  if (1 != EVP_EncryptInit(ctx.get(), cipher, key.data(), nonce.data())) {
-    throw openssl_error();
-  }
-
-  int outlen = 0;
-  auto aad_size_int = static_cast<int>(aad.size());
-  if (aad.size() > 0) {
-    if (1 != EVP_EncryptUpdate(
-               ctx.get(), nullptr, &outlen, aad.data(), aad_size_int)) {
-      throw openssl_error();
-    }
-  }
-
-  auto pt_size_int = static_cast<int>(pt.size());
-  if (1 != EVP_EncryptUpdate(
-             ctx.get(), ct.data(), &outlen, pt.data(), pt_size_int)) {
-    throw openssl_error();
-  }
-
-  // Providing nullptr as an argument is safe here because this
-  // function never writes with GCM; it only computes the tag
-  if (1 != EVP_EncryptFinal(ctx.get(), nullptr, &outlen)) {
-    throw openssl_error();
-  }
-
-  auto tag = ct.subspan(pt.size(), tag_size);
-  auto tag_ptr = const_cast<void*>(static_cast<const void*>(tag.data()));
-  auto tag_size_downcast = static_cast<int>(tag.size());
-  if (1 != EVP_CIPHER_CTX_ctrl(
-             ctx.get(), EVP_CTRL_GCM_GET_TAG, tag_size_downcast, tag_ptr)) {
-    throw openssl_error();
-  }
-
-  return ct.subspan(0, pt.size() + tag_size);
-}
-
-output_bytes
-seal(CipherSuite suite,
-     input_bytes key,
-     input_bytes nonce,
-     output_bytes ct,
-     input_bytes aad,
-     input_bytes pt)
+size_t
+cipher_overhead(CipherSuite suite)
 {
   switch (suite) {
     case CipherSuite::AES_128_CTR_HMAC_SHA256_80:
+      return 10;
+
     case CipherSuite::AES_128_CTR_HMAC_SHA256_64:
-    case CipherSuite::AES_128_CTR_HMAC_SHA256_32: {
-      return seal_ctr(suite, key, nonce, ct, aad, pt);
-    }
+      return 8;
+
+    case CipherSuite::AES_128_CTR_HMAC_SHA256_32:
+      return 4;
 
     case CipherSuite::AES_GCM_128_SHA256:
-    case CipherSuite::AES_GCM_256_SHA512: {
-      return seal_aead(suite, key, nonce, ct, aad, pt);
-    }
+    case CipherSuite::AES_GCM_256_SHA512:
+      return 16;
+
+    default:
+      throw unsupported_ciphersuite_error();
   }
-
-  throw unsupported_ciphersuite_error();
-}
-
-static output_bytes
-open_ctr(CipherSuite suite,
-         input_bytes key,
-         input_bytes nonce,
-         output_bytes pt,
-         input_bytes aad,
-         input_bytes ct)
-{
-  auto tag_size = overhead(suite);
-  if (ct.size() < tag_size) {
-    throw buffer_too_small_error("Ciphertext buffer too small");
-  }
-
-  auto inner_ct_size = ct.size() - tag_size;
-  auto inner_ct = ct.subspan(0, inner_ct_size);
-  auto tag = ct.subspan(inner_ct_size, tag_size);
-
-  // Split the key into enc and auth subkeys
-  auto enc_key_size = cipher_enc_key_size(suite);
-  auto enc_key = key.first(enc_key_size);
-  auto auth_key = key.subspan(enc_key_size);
-
-  // Authenticate with truncated HMAC
-  auto mac = compute_tag(suite, auth_key, nonce, aad, inner_ct, tag_size);
-  if (CRYPTO_memcmp(mac.data(), tag.data(), tag.size()) != 0) {
-    throw authentication_error();
-  }
-
-  // Decrypt with AES-CTR
-  const auto pt_out = pt.first(inner_ct_size);
-  ctr_crypt(suite, enc_key, nonce, pt_out, ct.first(inner_ct_size));
-
-  return pt_out;
-}
-
-static output_bytes
-open_aead(CipherSuite suite,
-          input_bytes key,
-          input_bytes nonce,
-          output_bytes pt,
-          input_bytes aad,
-          input_bytes ct)
-{
-  auto tag_size = overhead(suite);
-  if (ct.size() < tag_size) {
-    throw buffer_too_small_error("Ciphertext buffer too small");
-  }
-
-  auto inner_ct_size = ct.size() - tag_size;
-  if (pt.size() < inner_ct_size) {
-    throw buffer_too_small_error("Plaintext buffer too small");
-  }
-
-  auto ctx = scoped_evp_ctx(EVP_CIPHER_CTX_new(), EVP_CIPHER_CTX_free);
-  if (ctx.get() == nullptr) {
-    throw openssl_error();
-  }
-
-  auto cipher = openssl_cipher(suite);
-  if (1 != EVP_DecryptInit(ctx.get(), cipher, key.data(), nonce.data())) {
-    throw openssl_error();
-  }
-
-  auto tag = ct.subspan(inner_ct_size, tag_size);
-  auto tag_ptr = const_cast<void*>(static_cast<const void*>(tag.data()));
-  auto tag_size_downcast = static_cast<int>(tag.size());
-  if (1 != EVP_CIPHER_CTX_ctrl(
-             ctx.get(), EVP_CTRL_GCM_SET_TAG, tag_size_downcast, tag_ptr)) {
-    throw openssl_error();
-  }
-
-  int out_size;
-  auto aad_size_int = static_cast<int>(aad.size());
-  if (aad.size() > 0) {
-    if (1 != EVP_DecryptUpdate(
-               ctx.get(), nullptr, &out_size, aad.data(), aad_size_int)) {
-      throw openssl_error();
-    }
-  }
-
-  auto inner_ct_size_int = static_cast<int>(inner_ct_size);
-  if (1 != EVP_DecryptUpdate(
-             ctx.get(), pt.data(), &out_size, ct.data(), inner_ct_size_int)) {
-    throw openssl_error();
-  }
-
-  // Providing nullptr as an argument is safe here because this
-  // function never writes with GCM; it only verifies the tag
-  if (1 != EVP_DecryptFinal(ctx.get(), nullptr, &out_size)) {
-    throw authentication_error();
-  }
-
-  return pt.subspan(0, inner_ct_size);
-}
-
-output_bytes
-open(CipherSuite suite,
-     input_bytes key,
-     input_bytes nonce,
-     output_bytes pt,
-     input_bytes aad,
-     input_bytes ct)
-{
-  switch (suite) {
-    case CipherSuite::AES_128_CTR_HMAC_SHA256_80:
-    case CipherSuite::AES_128_CTR_HMAC_SHA256_64:
-    case CipherSuite::AES_128_CTR_HMAC_SHA256_32: {
-      return open_ctr(suite, key, nonce, pt, aad, ct);
-    }
-
-    case CipherSuite::AES_GCM_128_SHA256:
-    case CipherSuite::AES_GCM_256_SHA512: {
-      return open_aead(suite, key, nonce, pt, aad, ct);
-    }
-  }
-
-  throw unsupported_ciphersuite_error();
 }
 
 } // namespace sframe

--- a/src/crypto.h
+++ b/src/crypto.h
@@ -1,59 +1,37 @@
 #pragma once
 
-#include <openssl/hmac.h>
 #include <sframe/sframe.h>
 
 namespace sframe {
-
-///
-/// Scoped pointers for OpenSSL objects
-///
-
-using scoped_evp_ctx =
-  std::unique_ptr<EVP_CIPHER_CTX, decltype(&EVP_CIPHER_CTX_free)>;
-using scoped_hmac_ctx = std::unique_ptr<HMAC_CTX, decltype(&HMAC_CTX_free)>;
-
-///
-/// Information about algorithms
-///
 
 size_t
 cipher_digest_size(CipherSuite suite);
 size_t
 cipher_key_size(CipherSuite suite);
 size_t
+cipher_enc_key_size(CipherSuite suite);
+size_t
 cipher_nonce_size(CipherSuite suite);
+size_t
+cipher_overhead(CipherSuite suite);
 
 ///
-/// HMAC and HKDF
+/// HKDF
 ///
-
-struct HMAC
-{
-  using Output = owned_bytes<EVP_MAX_MD_SIZE>;
-
-  HMAC(CipherSuite suite, input_bytes key);
-  void write(input_bytes data);
-  Output digest();
-
-private:
-  scoped_hmac_ctx ctx;
-};
-
-HMAC::Output
-hkdf_extract(CipherSuite suite, input_bytes salt, input_bytes ikm);
 
 static constexpr size_t max_hkdf_extract_size = 64;
+static constexpr size_t max_hkdf_expand_size = 64;
 
 owned_bytes<max_hkdf_extract_size>
+hkdf_extract(CipherSuite suite, input_bytes salt, input_bytes ikm);
+
+
+owned_bytes<max_hkdf_expand_size>
 hkdf_expand(CipherSuite suite, input_bytes prk, input_bytes info, size_t size);
 
 ///
 /// AEAD Algorithms
 ///
-
-size_t
-overhead(CipherSuite suite);
 
 output_bytes
 seal(CipherSuite suite,

--- a/src/crypto_openssl11.cpp
+++ b/src/crypto_openssl11.cpp
@@ -1,0 +1,474 @@
+#if defined(OPENSSL_1_1)
+
+#include "crypto.h"
+#include "header.h"
+
+#include <openssl/err.h>
+#include <openssl/evp.h>
+#include <openssl/hmac.h>
+
+namespace sframe {
+
+///
+/// Scoped pointers for OpenSSL objects
+///
+
+using scoped_evp_ctx =
+  std::unique_ptr<EVP_CIPHER_CTX, decltype(&EVP_CIPHER_CTX_free)>;
+using scoped_hmac_ctx = std::unique_ptr<HMAC_CTX, decltype(&HMAC_CTX_free)>;
+
+///
+/// Convert between native identifiers / errors and OpenSSL ones
+///
+
+crypto_error::crypto_error()
+  : std::runtime_error(ERR_error_string(ERR_get_error(), nullptr))
+{
+}
+
+static const EVP_MD*
+openssl_digest_type(CipherSuite suite)
+{
+  switch (suite) {
+    case CipherSuite::AES_128_CTR_HMAC_SHA256_80:
+    case CipherSuite::AES_128_CTR_HMAC_SHA256_64:
+    case CipherSuite::AES_128_CTR_HMAC_SHA256_32:
+    case CipherSuite::AES_GCM_128_SHA256:
+      return EVP_sha256();
+
+    case CipherSuite::AES_GCM_256_SHA512:
+      return EVP_sha512();
+
+    default:
+      throw unsupported_ciphersuite_error();
+  }
+}
+
+static const EVP_CIPHER*
+openssl_cipher(CipherSuite suite)
+{
+  switch (suite) {
+    case CipherSuite::AES_128_CTR_HMAC_SHA256_80:
+    case CipherSuite::AES_128_CTR_HMAC_SHA256_64:
+    case CipherSuite::AES_128_CTR_HMAC_SHA256_32:
+      return EVP_aes_128_ctr();
+
+    case CipherSuite::AES_GCM_128_SHA256:
+      return EVP_aes_128_gcm();
+
+    case CipherSuite::AES_GCM_256_SHA512:
+      return EVP_aes_256_gcm();
+
+    default:
+      throw unsupported_ciphersuite_error();
+  }
+}
+
+///
+/// HMAC and HKDF
+///
+
+struct HMAC
+{
+private:
+
+  scoped_hmac_ctx ctx;
+
+public:
+  HMAC(CipherSuite suite, input_bytes key)
+    : ctx(HMAC_CTX_new(), HMAC_CTX_free)
+  {
+    const auto type = openssl_digest_type(suite);
+
+    // Some FIPS-enabled libraries are overly conservative in their interpretation
+    // of NIST SP 800-131A, which requires HMAC keys to be at least 112 bits long.
+    // That document does not impose that requirement on HKDF, so we disable FIPS
+    // enforcement for purposes of HKDF.
+    //
+    // https://doi.org/10.6028/NIST.SP.800-131Ar2
+    static const auto fips_min_hmac_key_len = 14;
+    auto key_size = static_cast<int>(key.size());
+    if (FIPS_mode() != 0 && key_size < fips_min_hmac_key_len) {
+      HMAC_CTX_set_flags(ctx.get(), EVP_MD_CTX_FLAG_NON_FIPS_ALLOW);
+    }
+
+    // Guard against sending nullptr to HMAC_Init_ex
+    const auto* key_data = key.data();
+    const auto non_null_zero_length_key = uint8_t(0);
+    if (key_data == nullptr) {
+      key_data = &non_null_zero_length_key;
+    }
+
+    if (1 != HMAC_Init_ex(ctx.get(), key_data, key_size, type, nullptr)) {
+      throw crypto_error();
+    }
+  }
+
+  void write(input_bytes data)
+  {
+    if (1 != HMAC_Update(ctx.get(), data.data(), data.size())) {
+      throw crypto_error();
+    }
+  }
+
+
+  output_bytes digest(output_bytes md)
+  {
+    unsigned int size = md.size();
+    if (1 != HMAC_Final(ctx.get(), md.data(), &size)) {
+      throw crypto_error();
+    }
+
+    return md.first(size);
+  }
+};
+
+///
+/// HKDF
+///
+
+owned_bytes<max_hkdf_expand_size>
+hkdf_extract(CipherSuite suite, input_bytes salt, input_bytes ikm)
+{
+  auto h = HMAC(suite, salt);
+  h.write(ikm);
+
+  auto out = owned_bytes<max_hkdf_expand_size>();
+  const auto md = h.digest(out);
+  out.resize(md.size());
+  return out;
+}
+
+owned_bytes<max_hkdf_extract_size>
+hkdf_expand(CipherSuite suite, input_bytes prk, input_bytes info, size_t size)
+{
+  // Ensure that we need only one hash invocation
+  if (size > max_hkdf_extract_size) {
+    throw invalid_parameter_error("Size too big for hkdf_expand");
+  }
+
+  auto out = owned_bytes<max_hkdf_extract_size>(0);
+
+  auto block = owned_bytes<max_hkdf_extract_size>(0);
+  const auto block_size = cipher_digest_size(suite);
+  auto counter = uint8_t(0x01);
+  while (out.size() < size) {
+    // for (auto start = size_t(0); start < out.size(); start += block_size) {
+    auto h = HMAC(suite, prk);
+    h.write(block);
+    h.write(info);
+    h.write(owned_bytes<1>{ counter });
+
+    block.resize(block.capacity());
+    const auto md = h.digest(block);
+    block.resize(md.size());
+
+    const auto remaining = size - out.size();
+    const auto to_write = (remaining < block_size) ? remaining : block_size;
+    out.append(input_bytes(block).first(to_write));
+
+    counter += 1;
+  }
+
+  return out;
+}
+
+///
+/// AEAD Algorithms
+///
+
+static owned_bytes<64>
+compute_tag(CipherSuite suite,
+            input_bytes auth_key,
+            input_bytes nonce,
+            input_bytes aad,
+            input_bytes ct,
+            size_t tag_size)
+{
+  auto len_block = owned_bytes<24>();
+  auto len_view = output_bytes(len_block);
+  encode_uint(aad.size(), len_view.first(8));
+  encode_uint(ct.size(), len_view.first(16).last(8));
+  encode_uint(tag_size, len_view.last(8));
+
+  auto h = HMAC(suite, auth_key);
+  h.write(len_block);
+  h.write(nonce);
+  h.write(aad);
+  h.write(ct);
+
+  auto tag = owned_bytes<64>();
+  h.digest(tag);
+  tag.resize(tag_size);
+  return tag;
+}
+
+static void
+ctr_crypt(CipherSuite suite,
+          input_bytes key,
+          input_bytes nonce,
+          output_bytes out,
+          input_bytes in)
+{
+  if (out.size() != in.size()) {
+    throw buffer_too_small_error("CTR size mismatch");
+  }
+
+  auto ctx = scoped_evp_ctx(EVP_CIPHER_CTX_new(), EVP_CIPHER_CTX_free);
+  if (ctx.get() == nullptr) {
+    throw crypto_error();
+  }
+
+  auto padded_nonce = owned_bytes<16>(0);
+  padded_nonce.append(nonce);
+  padded_nonce.resize(16);
+
+  auto cipher = openssl_cipher(suite);
+  if (1 !=
+      EVP_EncryptInit(ctx.get(), cipher, key.data(), padded_nonce.data())) {
+    throw crypto_error();
+  }
+
+  int outlen = 0;
+  auto in_size_int = static_cast<int>(in.size());
+  if (1 != EVP_EncryptUpdate(
+             ctx.get(), out.data(), &outlen, in.data(), in_size_int)) {
+    throw crypto_error();
+  }
+
+  if (1 != EVP_EncryptFinal(ctx.get(), nullptr, &outlen)) {
+    throw crypto_error();
+  }
+}
+
+static output_bytes
+seal_ctr(CipherSuite suite,
+         input_bytes key,
+         input_bytes nonce,
+         output_bytes ct,
+         input_bytes aad,
+         input_bytes pt)
+{
+  auto tag_size = cipher_overhead(suite);
+  if (ct.size() < pt.size() + tag_size) {
+    throw buffer_too_small_error("Ciphertext buffer too small");
+  }
+
+  // Split the key into enc and auth subkeys
+  auto enc_key_size = cipher_enc_key_size(suite);
+  auto enc_key = key.first(enc_key_size);
+  auto auth_key = key.subspan(enc_key_size);
+
+  // Encrypt with AES-CM
+  auto inner_ct = ct.subspan(0, pt.size());
+  ctr_crypt(suite, enc_key, nonce, inner_ct, pt);
+
+  // Authenticate with truncated HMAC
+  auto mac = compute_tag(suite, auth_key, nonce, aad, inner_ct, tag_size);
+  auto tag = ct.subspan(pt.size(), tag_size);
+  std::copy(mac.begin(), mac.begin() + tag_size, tag.begin());
+
+  return ct.subspan(0, pt.size() + tag_size);
+}
+
+static output_bytes
+seal_aead(CipherSuite suite,
+          input_bytes key,
+          input_bytes nonce,
+          output_bytes ct,
+          input_bytes aad,
+          input_bytes pt)
+{
+  auto tag_size = cipher_overhead(suite);
+  if (ct.size() < pt.size() + tag_size) {
+    throw buffer_too_small_error("Ciphertext buffer too small");
+  }
+
+  auto ctx = scoped_evp_ctx(EVP_CIPHER_CTX_new(), EVP_CIPHER_CTX_free);
+  if (ctx.get() == nullptr) {
+    throw crypto_error();
+  }
+
+  auto cipher = openssl_cipher(suite);
+  if (1 != EVP_EncryptInit(ctx.get(), cipher, key.data(), nonce.data())) {
+    throw crypto_error();
+  }
+
+  int outlen = 0;
+  auto aad_size_int = static_cast<int>(aad.size());
+  if (aad.size() > 0) {
+    if (1 != EVP_EncryptUpdate(
+               ctx.get(), nullptr, &outlen, aad.data(), aad_size_int)) {
+      throw crypto_error();
+    }
+  }
+
+  auto pt_size_int = static_cast<int>(pt.size());
+  if (1 != EVP_EncryptUpdate(
+             ctx.get(), ct.data(), &outlen, pt.data(), pt_size_int)) {
+    throw crypto_error();
+  }
+
+  // Providing nullptr as an argument is safe here because this
+  // function never writes with GCM; it only computes the tag
+  if (1 != EVP_EncryptFinal(ctx.get(), nullptr, &outlen)) {
+    throw crypto_error();
+  }
+
+  auto tag = ct.subspan(pt.size(), tag_size);
+  auto tag_ptr = const_cast<void*>(static_cast<const void*>(tag.data()));
+  auto tag_size_downcast = static_cast<int>(tag.size());
+  if (1 != EVP_CIPHER_CTX_ctrl(
+             ctx.get(), EVP_CTRL_GCM_GET_TAG, tag_size_downcast, tag_ptr)) {
+    throw crypto_error();
+  }
+
+  return ct.subspan(0, pt.size() + tag_size);
+}
+
+output_bytes
+seal(CipherSuite suite,
+     input_bytes key,
+     input_bytes nonce,
+     output_bytes ct,
+     input_bytes aad,
+     input_bytes pt)
+{
+  switch (suite) {
+    case CipherSuite::AES_128_CTR_HMAC_SHA256_80:
+    case CipherSuite::AES_128_CTR_HMAC_SHA256_64:
+    case CipherSuite::AES_128_CTR_HMAC_SHA256_32: {
+      return seal_ctr(suite, key, nonce, ct, aad, pt);
+    }
+
+    case CipherSuite::AES_GCM_128_SHA256:
+    case CipherSuite::AES_GCM_256_SHA512: {
+      return seal_aead(suite, key, nonce, ct, aad, pt);
+    }
+  }
+
+  throw unsupported_ciphersuite_error();
+}
+
+static output_bytes
+open_ctr(CipherSuite suite,
+         input_bytes key,
+         input_bytes nonce,
+         output_bytes pt,
+         input_bytes aad,
+         input_bytes ct)
+{
+  auto tag_size = cipher_overhead(suite);
+  if (ct.size() < tag_size) {
+    throw buffer_too_small_error("Ciphertext buffer too small");
+  }
+
+  auto inner_ct_size = ct.size() - tag_size;
+  auto inner_ct = ct.subspan(0, inner_ct_size);
+  auto tag = ct.subspan(inner_ct_size, tag_size);
+
+  // Split the key into enc and auth subkeys
+  auto enc_key_size = cipher_enc_key_size(suite);
+  auto enc_key = key.first(enc_key_size);
+  auto auth_key = key.subspan(enc_key_size);
+
+  // Authenticate with truncated HMAC
+  auto mac = compute_tag(suite, auth_key, nonce, aad, inner_ct, tag_size);
+  if (CRYPTO_memcmp(mac.data(), tag.data(), tag.size()) != 0) {
+    throw authentication_error();
+  }
+
+  // Decrypt with AES-CTR
+  const auto pt_out = pt.first(inner_ct_size);
+  ctr_crypt(suite, enc_key, nonce, pt_out, ct.first(inner_ct_size));
+
+  return pt_out;
+}
+
+static output_bytes
+open_aead(CipherSuite suite,
+          input_bytes key,
+          input_bytes nonce,
+          output_bytes pt,
+          input_bytes aad,
+          input_bytes ct)
+{
+  auto tag_size = cipher_overhead(suite);
+  if (ct.size() < tag_size) {
+    throw buffer_too_small_error("Ciphertext buffer too small");
+  }
+
+  auto inner_ct_size = ct.size() - tag_size;
+  if (pt.size() < inner_ct_size) {
+    throw buffer_too_small_error("Plaintext buffer too small");
+  }
+
+  auto ctx = scoped_evp_ctx(EVP_CIPHER_CTX_new(), EVP_CIPHER_CTX_free);
+  if (ctx.get() == nullptr) {
+    throw crypto_error();
+  }
+
+  auto cipher = openssl_cipher(suite);
+  if (1 != EVP_DecryptInit(ctx.get(), cipher, key.data(), nonce.data())) {
+    throw crypto_error();
+  }
+
+  auto tag = ct.subspan(inner_ct_size, tag_size);
+  auto tag_ptr = const_cast<void*>(static_cast<const void*>(tag.data()));
+  auto tag_size_downcast = static_cast<int>(tag.size());
+  if (1 != EVP_CIPHER_CTX_ctrl(
+             ctx.get(), EVP_CTRL_GCM_SET_TAG, tag_size_downcast, tag_ptr)) {
+    throw crypto_error();
+  }
+
+  int out_size;
+  auto aad_size_int = static_cast<int>(aad.size());
+  if (aad.size() > 0) {
+    if (1 != EVP_DecryptUpdate(
+               ctx.get(), nullptr, &out_size, aad.data(), aad_size_int)) {
+      throw crypto_error();
+    }
+  }
+
+  auto inner_ct_size_int = static_cast<int>(inner_ct_size);
+  if (1 != EVP_DecryptUpdate(
+             ctx.get(), pt.data(), &out_size, ct.data(), inner_ct_size_int)) {
+    throw crypto_error();
+  }
+
+  // Providing nullptr as an argument is safe here because this
+  // function never writes with GCM; it only verifies the tag
+  if (1 != EVP_DecryptFinal(ctx.get(), nullptr, &out_size)) {
+    throw authentication_error();
+  }
+
+  return pt.subspan(0, inner_ct_size);
+}
+
+output_bytes
+open(CipherSuite suite,
+     input_bytes key,
+     input_bytes nonce,
+     output_bytes pt,
+     input_bytes aad,
+     input_bytes ct)
+{
+  switch (suite) {
+    case CipherSuite::AES_128_CTR_HMAC_SHA256_80:
+    case CipherSuite::AES_128_CTR_HMAC_SHA256_64:
+    case CipherSuite::AES_128_CTR_HMAC_SHA256_32: {
+      return open_ctr(suite, key, nonce, pt, aad, ct);
+    }
+
+    case CipherSuite::AES_GCM_128_SHA256:
+    case CipherSuite::AES_GCM_256_SHA512: {
+      return open_aead(suite, key, nonce, pt, aad, ct);
+    }
+  }
+
+  throw unsupported_ciphersuite_error();
+}
+
+} // namespace sframe
+
+#endif // defined(OPENSSL_1_1)

--- a/src/crypto_openssl3.cpp
+++ b/src/crypto_openssl3.cpp
@@ -1,0 +1,457 @@
+#if defined(OPENSSL_3)
+
+#include "crypto.h"
+#include "header.h"
+
+#include <openssl/err.h>
+#include <openssl/evp.h>
+#include <openssl/kdf.h>
+#include <openssl/params.h>
+#include <openssl/core_names.h>
+
+namespace sframe {
+
+///
+/// Convert between native identifiers / errors and OpenSSL ones
+///
+
+crypto_error::crypto_error()
+  : std::runtime_error(ERR_error_string(ERR_get_error(), nullptr))
+{
+}
+
+static const EVP_CIPHER*
+openssl_cipher(CipherSuite suite)
+{
+  switch (suite) {
+    case CipherSuite::AES_128_CTR_HMAC_SHA256_80:
+    case CipherSuite::AES_128_CTR_HMAC_SHA256_64:
+    case CipherSuite::AES_128_CTR_HMAC_SHA256_32:
+      return EVP_aes_128_ctr();
+
+    case CipherSuite::AES_GCM_128_SHA256:
+      return EVP_aes_128_gcm();
+
+    case CipherSuite::AES_GCM_256_SHA512:
+      return EVP_aes_256_gcm();
+
+    default:
+      throw unsupported_ciphersuite_error();
+  }
+}
+
+static std::string
+openssl_digest_name(CipherSuite suite)
+{
+  switch (suite) {
+    case CipherSuite::AES_128_CTR_HMAC_SHA256_80:
+    case CipherSuite::AES_128_CTR_HMAC_SHA256_64:
+    case CipherSuite::AES_128_CTR_HMAC_SHA256_32:
+    case CipherSuite::AES_GCM_128_SHA256:
+      return OSSL_DIGEST_NAME_SHA2_256;
+
+    case CipherSuite::AES_GCM_256_SHA512:
+      return OSSL_DIGEST_NAME_SHA2_512;
+
+    default:
+      throw unsupported_ciphersuite_error();
+  }
+}
+
+///
+/// HKDF
+///
+
+using scoped_evp_kdf = std::unique_ptr<EVP_KDF, decltype(&EVP_KDF_free)>;
+using scoped_evp_kdf_ctx = std::unique_ptr<EVP_KDF_CTX, decltype(&EVP_KDF_CTX_free)>;
+
+owned_bytes<max_hkdf_expand_size>
+hkdf_extract(CipherSuite suite, input_bytes salt, input_bytes ikm)
+{
+  auto mode = EVP_KDF_HKDF_MODE_EXTRACT_ONLY;
+  auto digest_name = openssl_digest_name(suite);
+  auto* salt_ptr = const_cast<void*>(reinterpret_cast<const void*>(salt.data()));
+  auto* ikm_ptr = const_cast<void*>(reinterpret_cast<const void*>(ikm.data()));
+
+  const auto params = std::array<OSSL_PARAM, 5>{
+    OSSL_PARAM_construct_int(OSSL_KDF_PARAM_MODE, &mode),
+    OSSL_PARAM_construct_utf8_string(OSSL_KDF_PARAM_DIGEST, digest_name.data(), digest_name.size()),
+    OSSL_PARAM_construct_octet_string(OSSL_KDF_PARAM_KEY, ikm_ptr, ikm.size()),
+    OSSL_PARAM_construct_octet_string(OSSL_KDF_PARAM_SALT, salt_ptr, salt.size()),
+    OSSL_PARAM_construct_end(),
+  };
+
+  const auto kdf = scoped_evp_kdf(EVP_KDF_fetch(NULL, "HKDF", NULL), EVP_KDF_free);
+  const auto ctx = scoped_evp_kdf_ctx(EVP_KDF_CTX_new(kdf.get()), EVP_KDF_CTX_free);
+  if (1 != EVP_KDF_CTX_set_params(ctx.get(), params.data())) {
+    throw crypto_error();
+  }
+
+  const auto digest_size = EVP_KDF_CTX_get_kdf_size(ctx.get());
+  auto out = owned_bytes<max_hkdf_expand_size>(digest_size);
+  if (1 != EVP_KDF_derive(ctx.get(), out.data(), out.size(), nullptr)) {
+      throw crypto_error();
+  }
+
+  return out;
+}
+
+owned_bytes<max_hkdf_extract_size>
+hkdf_expand(CipherSuite suite, input_bytes prk, input_bytes info, size_t size)
+{
+  auto mode = EVP_KDF_HKDF_MODE_EXPAND_ONLY;
+  auto digest_name = openssl_digest_name(suite);
+  auto* prk_ptr = const_cast<void*>(reinterpret_cast<const void*>(prk.data()));
+  auto* info_ptr = const_cast<void*>(reinterpret_cast<const void*>(info.data()));
+
+  const auto params = std::array<OSSL_PARAM, 5>{
+    OSSL_PARAM_construct_int(OSSL_KDF_PARAM_MODE, &mode),
+    OSSL_PARAM_construct_utf8_string(OSSL_KDF_PARAM_DIGEST, digest_name.data(), digest_name.size()),
+    OSSL_PARAM_construct_octet_string(OSSL_KDF_PARAM_KEY, prk_ptr, prk.size()),
+    OSSL_PARAM_construct_octet_string(OSSL_KDF_PARAM_INFO, info_ptr, info.size()),
+    OSSL_PARAM_construct_end(),
+  };
+
+  const auto kdf = scoped_evp_kdf(EVP_KDF_fetch(NULL, "HKDF", NULL), EVP_KDF_free);
+  const auto ctx = scoped_evp_kdf_ctx(EVP_KDF_CTX_new(kdf.get()), EVP_KDF_CTX_free);
+
+  auto out = owned_bytes<max_hkdf_expand_size>(size);
+  if (1 != EVP_KDF_derive(ctx.get(), out.data(), out.size(), params.data())) {
+      throw crypto_error();
+  }
+
+  return out;
+}
+
+///
+/// AEAD Algorithms
+///
+
+static owned_bytes<64>
+compute_tag(CipherSuite suite,
+            input_bytes auth_key,
+            input_bytes nonce,
+            input_bytes aad,
+            input_bytes ct,
+            size_t tag_size)
+{
+  using scoped_evp_mac = std::unique_ptr<EVP_MAC, decltype(&EVP_MAC_free)>;
+  using scoped_evp_mac_ctx = std::unique_ptr<EVP_MAC_CTX, decltype(&EVP_MAC_CTX_free)>;
+
+  auto len_block = owned_bytes<24>();
+  auto len_view = output_bytes(len_block);
+  encode_uint(aad.size(), len_view.first(8));
+  encode_uint(ct.size(), len_view.first(16).last(8));
+  encode_uint(tag_size, len_view.last(8));
+
+  auto digest_name = openssl_digest_name(suite);
+  std::array<OSSL_PARAM, 2> params = {
+    OSSL_PARAM_construct_utf8_string(
+      OSSL_ALG_PARAM_DIGEST, digest_name.data(), 0),
+    OSSL_PARAM_construct_end()
+  };
+
+  const auto mac = scoped_evp_mac(EVP_MAC_fetch(nullptr, OSSL_MAC_NAME_HMAC, nullptr), EVP_MAC_free);
+  const auto ctx = scoped_evp_mac_ctx(EVP_MAC_CTX_new(mac.get()), EVP_MAC_CTX_free);
+
+  if (1 != EVP_MAC_init(ctx.get(), auth_key.data(), auth_key.size(), params.data())) {
+    throw crypto_error();
+  }
+
+  if (1 != EVP_MAC_update(ctx.get(), len_block.data(), len_block.size())) {
+    throw crypto_error();
+  }
+
+  if (1 != EVP_MAC_update(ctx.get(), nonce.data(), nonce.size())) {
+    throw crypto_error();
+  }
+
+  if (1 != EVP_MAC_update(ctx.get(), aad.data(), aad.size())) {
+    throw crypto_error();
+  }
+
+  if (1 != EVP_MAC_update(ctx.get(), ct.data(), ct.size())) {
+    throw crypto_error();
+  }
+
+  size_t size = 0;
+  auto tag = owned_bytes<64>();
+  if (1 != EVP_MAC_final(ctx.get(), tag.data(), &size, tag.size())) {
+    throw crypto_error();
+  }
+
+  tag.resize(tag_size);
+  return tag;
+}
+
+using scoped_evp_cipher_ctx = std::unique_ptr<EVP_CIPHER_CTX, decltype(&EVP_CIPHER_CTX_free)>;
+
+static void
+ctr_crypt(CipherSuite suite,
+          input_bytes key,
+          input_bytes nonce,
+          output_bytes out,
+          input_bytes in)
+{
+  if (out.size() != in.size()) {
+    throw buffer_too_small_error("CTR size mismatch");
+  }
+
+  auto ctx = scoped_evp_cipher_ctx(EVP_CIPHER_CTX_new(), EVP_CIPHER_CTX_free);
+  if (ctx.get() == nullptr) {
+    throw crypto_error();
+  }
+
+  auto padded_nonce = owned_bytes<16>(0);
+  padded_nonce.append(nonce);
+  padded_nonce.resize(16);
+
+  auto cipher = openssl_cipher(suite);
+  if (1 !=
+      EVP_EncryptInit(ctx.get(), cipher, key.data(), padded_nonce.data())) {
+    throw crypto_error();
+  }
+
+  int outlen = 0;
+  auto in_size_int = static_cast<int>(in.size());
+  if (1 != EVP_EncryptUpdate(
+             ctx.get(), out.data(), &outlen, in.data(), in_size_int)) {
+    throw crypto_error();
+  }
+
+  if (1 != EVP_EncryptFinal(ctx.get(), nullptr, &outlen)) {
+    throw crypto_error();
+  }
+}
+
+static output_bytes
+seal_ctr(CipherSuite suite,
+         input_bytes key,
+         input_bytes nonce,
+         output_bytes ct,
+         input_bytes aad,
+         input_bytes pt)
+{
+  auto tag_size = cipher_overhead(suite);
+  if (ct.size() < pt.size() + tag_size) {
+    throw buffer_too_small_error("Ciphertext buffer too small");
+  }
+
+  // Split the key into enc and auth subkeys
+  auto enc_key_size = cipher_enc_key_size(suite);
+  auto enc_key = key.first(enc_key_size);
+  auto auth_key = key.subspan(enc_key_size);
+
+  // Encrypt with AES-CM
+  auto inner_ct = ct.subspan(0, pt.size());
+  ctr_crypt(suite, enc_key, nonce, inner_ct, pt);
+
+  // Authenticate with truncated HMAC
+  auto mac = compute_tag(suite, auth_key, nonce, aad, inner_ct, tag_size);
+  auto tag = ct.subspan(pt.size(), tag_size);
+  std::copy(mac.begin(), mac.begin() + tag_size, tag.begin());
+
+  return ct.subspan(0, pt.size() + tag_size);
+}
+
+static output_bytes
+seal_aead(CipherSuite suite,
+          input_bytes key,
+          input_bytes nonce,
+          output_bytes ct,
+          input_bytes aad,
+          input_bytes pt)
+{
+  auto tag_size = cipher_overhead(suite);
+  if (ct.size() < pt.size() + tag_size) {
+    throw buffer_too_small_error("Ciphertext buffer too small");
+  }
+
+  auto ctx = scoped_evp_cipher_ctx(EVP_CIPHER_CTX_new(), EVP_CIPHER_CTX_free);
+  if (ctx.get() == nullptr) {
+    throw crypto_error();
+  }
+
+  auto cipher = openssl_cipher(suite);
+  if (1 != EVP_EncryptInit(ctx.get(), cipher, key.data(), nonce.data())) {
+    throw crypto_error();
+  }
+
+  int outlen = 0;
+  auto aad_size_int = static_cast<int>(aad.size());
+  if (aad.size() > 0) {
+    if (1 != EVP_EncryptUpdate(
+               ctx.get(), nullptr, &outlen, aad.data(), aad_size_int)) {
+      throw crypto_error();
+    }
+  }
+
+  auto pt_size_int = static_cast<int>(pt.size());
+  if (1 != EVP_EncryptUpdate(
+             ctx.get(), ct.data(), &outlen, pt.data(), pt_size_int)) {
+    throw crypto_error();
+  }
+
+  // Providing nullptr as an argument is safe here because this
+  // function never writes with GCM; it only computes the tag
+  if (1 != EVP_EncryptFinal(ctx.get(), nullptr, &outlen)) {
+    throw crypto_error();
+  }
+
+  auto tag = ct.subspan(pt.size(), tag_size);
+  auto tag_ptr = const_cast<void*>(static_cast<const void*>(tag.data()));
+  auto tag_size_downcast = static_cast<int>(tag.size());
+  if (1 != EVP_CIPHER_CTX_ctrl(
+             ctx.get(), EVP_CTRL_GCM_GET_TAG, tag_size_downcast, tag_ptr)) {
+    throw crypto_error();
+  }
+
+  return ct.subspan(0, pt.size() + tag_size);
+}
+
+output_bytes
+seal(CipherSuite suite,
+     input_bytes key,
+     input_bytes nonce,
+     output_bytes ct,
+     input_bytes aad,
+     input_bytes pt)
+{
+  switch (suite) {
+    case CipherSuite::AES_128_CTR_HMAC_SHA256_80:
+    case CipherSuite::AES_128_CTR_HMAC_SHA256_64:
+    case CipherSuite::AES_128_CTR_HMAC_SHA256_32: {
+      return seal_ctr(suite, key, nonce, ct, aad, pt);
+    }
+
+    case CipherSuite::AES_GCM_128_SHA256:
+    case CipherSuite::AES_GCM_256_SHA512: {
+      return seal_aead(suite, key, nonce, ct, aad, pt);
+    }
+  }
+
+  throw unsupported_ciphersuite_error();
+}
+
+static output_bytes
+open_ctr(CipherSuite suite,
+         input_bytes key,
+         input_bytes nonce,
+         output_bytes pt,
+         input_bytes aad,
+         input_bytes ct)
+{
+  auto tag_size = cipher_overhead(suite);
+  if (ct.size() < tag_size) {
+    throw buffer_too_small_error("Ciphertext buffer too small");
+  }
+
+  auto inner_ct_size = ct.size() - tag_size;
+  auto inner_ct = ct.subspan(0, inner_ct_size);
+  auto tag = ct.subspan(inner_ct_size, tag_size);
+
+  // Split the key into enc and auth subkeys
+  auto enc_key_size = cipher_enc_key_size(suite);
+  auto enc_key = key.first(enc_key_size);
+  auto auth_key = key.subspan(enc_key_size);
+
+  // Authenticate with truncated HMAC
+  auto mac = compute_tag(suite, auth_key, nonce, aad, inner_ct, tag_size);
+  if (CRYPTO_memcmp(mac.data(), tag.data(), tag.size()) != 0) {
+    throw authentication_error();
+  }
+
+  // Decrypt with AES-CTR
+  const auto pt_out = pt.first(inner_ct_size);
+  ctr_crypt(suite, enc_key, nonce, pt_out, ct.first(inner_ct_size));
+
+  return pt_out;
+}
+
+static output_bytes
+open_aead(CipherSuite suite,
+          input_bytes key,
+          input_bytes nonce,
+          output_bytes pt,
+          input_bytes aad,
+          input_bytes ct)
+{
+  auto tag_size = cipher_overhead(suite);
+  if (ct.size() < tag_size) {
+    throw buffer_too_small_error("Ciphertext buffer too small");
+  }
+
+  auto inner_ct_size = ct.size() - tag_size;
+  if (pt.size() < inner_ct_size) {
+    throw buffer_too_small_error("Plaintext buffer too small");
+  }
+
+  auto ctx = scoped_evp_cipher_ctx(EVP_CIPHER_CTX_new(), EVP_CIPHER_CTX_free);
+  if (ctx.get() == nullptr) {
+    throw crypto_error();
+  }
+
+  auto cipher = openssl_cipher(suite);
+  if (1 != EVP_DecryptInit(ctx.get(), cipher, key.data(), nonce.data())) {
+    throw crypto_error();
+  }
+
+  auto tag = ct.subspan(inner_ct_size, tag_size);
+  auto tag_ptr = const_cast<void*>(static_cast<const void*>(tag.data()));
+  auto tag_size_downcast = static_cast<int>(tag.size());
+  if (1 != EVP_CIPHER_CTX_ctrl(
+             ctx.get(), EVP_CTRL_GCM_SET_TAG, tag_size_downcast, tag_ptr)) {
+    throw crypto_error();
+  }
+
+  int out_size;
+  auto aad_size_int = static_cast<int>(aad.size());
+  if (aad.size() > 0) {
+    if (1 != EVP_DecryptUpdate(
+               ctx.get(), nullptr, &out_size, aad.data(), aad_size_int)) {
+      throw crypto_error();
+    }
+  }
+
+  auto inner_ct_size_int = static_cast<int>(inner_ct_size);
+  if (1 != EVP_DecryptUpdate(
+             ctx.get(), pt.data(), &out_size, ct.data(), inner_ct_size_int)) {
+    throw crypto_error();
+  }
+
+  // Providing nullptr as an argument is safe here because this
+  // function never writes with GCM; it only verifies the tag
+  if (1 != EVP_DecryptFinal(ctx.get(), nullptr, &out_size)) {
+    throw authentication_error();
+  }
+
+  return pt.subspan(0, inner_ct_size);
+}
+
+output_bytes
+open(CipherSuite suite,
+     input_bytes key,
+     input_bytes nonce,
+     output_bytes pt,
+     input_bytes aad,
+     input_bytes ct)
+{
+  switch (suite) {
+    case CipherSuite::AES_128_CTR_HMAC_SHA256_80:
+    case CipherSuite::AES_128_CTR_HMAC_SHA256_64:
+    case CipherSuite::AES_128_CTR_HMAC_SHA256_32: {
+      return open_ctr(suite, key, nonce, pt, aad, ct);
+    }
+
+    case CipherSuite::AES_GCM_128_SHA256:
+    case CipherSuite::AES_GCM_256_SHA512: {
+      return open_aead(suite, key, nonce, pt, aad, ct);
+    }
+  }
+
+  throw unsupported_ciphersuite_error();
+}
+
+} // namespace sframe
+
+#endif // defined(OPENSSL_3)

--- a/src/sframe.cpp
+++ b/src/sframe.cpp
@@ -62,7 +62,7 @@ ContextBase::protect(const Header& header,
                      input_bytes plaintext,
                      input_bytes metadata)
 {
-  if (ciphertext.size() < plaintext.size() + overhead(suite)) {
+  if (ciphertext.size() < plaintext.size() + cipher_overhead(suite)) {
     throw buffer_too_small_error("Ciphertext too small for cipher overhead");
   }
 
@@ -79,11 +79,11 @@ ContextBase::unprotect(const Header& header,
                        input_bytes ciphertext,
                        input_bytes metadata)
 {
-  if (ciphertext.size() < overhead(suite)) {
+  if (ciphertext.size() < cipher_overhead(suite)) {
     throw buffer_too_small_error("Ciphertext too small for cipher overhead");
   }
 
-  if (plaintext.size() < ciphertext.size() - overhead(suite)) {
+  if (plaintext.size() < ciphertext.size() - cipher_overhead(suite)) {
     throw buffer_too_small_error("Plaintext too small for decrypted value");
   }
 

--- a/test/sframe.cpp
+++ b/test/sframe.cpp
@@ -15,10 +15,12 @@ using namespace sframe;
 static void
 ensure_fips_if_required()
 {
+#if defined(OPENSSL_1_1)
   const auto* require = std::getenv("REQUIRE_FIPS");
   if (require && FIPS_mode() == 0) {
     REQUIRE(FIPS_mode_set(1) == 1);
   }
+#endif
 }
 
 TEST_CASE("SFrame Round-Trip")

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -7,11 +7,11 @@
     "doctest",
     "nlohmann-json"    
   ],
-  "builtin-baseline": "3b3bd424827a1f7f4813216f6b32b6c61e386b2e",
+  "builtin-baseline": "7476f0d4e77d3333fbb249657df8251c28c4faae",
   "overrides": [
     {
       "name": "openssl",
-      "version-string": "1.1.1n"
+      "version-string": "3.1.2"
     }
   ]
 }


### PR DESCRIPTION
This PR implements a simple strategy for making it possible to plug in new crypto libraries.

* `crypto.h` is pared back to just the things required in `sframe.cpp`
* `crypto.cpp` only has things that are invariant regardless of the cryptographic library (properties of cipher suites)
* In `CMakeLists.txt`, we have a switch that adds a `#define` indicating which crypto library to use
* Crypto library specifics are in an implementation file, here `crypto_openssl11.cpp` or crypto_openssl3.cpp`.