### PR TITLE
Enable selective use of the C++ allocator

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,15 +51,20 @@ jobs:
             ${{ env.CMAKE_BUILD_DIR }}/vcpkg_installed
         key: ${{ runner.os }}-${{ hashFiles( '**/vcpkg.json' ) }}
 
-    - name: configure to use clang-tidy and sanitizers
+    - name: Build and run unit tests (with allocator)
       run: |
         cmake -B "${{ env.CMAKE_BUILD_DIR }}" -DCLANG_TIDY=ON -DTESTING=ON -DSANITIZERS=ON -DCMAKE_TOOLCHAIN_FILE="${{ matrix.vcpkg-cmake-file}}" .
-
-    - name: build
-      run: |
         cmake --build "${{ env.CMAKE_BUILD_DIR }}" --config Release
-
-    - name: Unit tests
-      run: |
         ctest --test-dir "${{ env.CMAKE_BUILD_DIR }}"
+
+    - name: Clear build artifacts
+      run: |
+        rm -rf "${{ env.CMAKE_BUILD_DIR }}"
+
+    - name: Build and run unit tests (without allocator)
+      run: |
+        cmake -B "${{ env.CMAKE_BUILD_DIR }}" -DCLANG_TIDY=ON -DTESTING=ON -DSANITIZERS=ON -DNO_ALLOC=ON -DCMAKE_TOOLCHAIN_FILE="${{ matrix.vcpkg-cmake-file}}" .
+        cmake --build "${{ env.CMAKE_BUILD_DIR }}" --config Release
+        ctest --test-dir "${{ env.CMAKE_BUILD_DIR }}"
+
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,7 @@ project(sframe
 option(TESTING    "Build tests" OFF)
 option(CLANG_TIDY "Perform linting with clang-tidy" OFF)
 option(SANITIZERS "Enable sanitizers" OFF)
+option(NO_ALLOC   "Build without needing an allocator" OFF)
 
 # Use -DCRYPTO=(OPENSSL_1_1 | OPENSSL_3) to configure crypto
 if(NOT DEFINED CRYPTO)
@@ -47,6 +48,11 @@ if(CLANG_TIDY)
   else()
     message(WARNING "clang-tidy requested, but not found")
   endif()
+endif()
+
+if(NO_ALLOC)
+  message(STATUS "Configuring no-allocator version")
+  add_definitions(-DNO_ALLOC)
 endif()
 
 ###

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,9 @@ ${BUILD_DIR}: CMakeLists.txt test/CMakeLists.txt
 dev: CMakeLists.txt test/CMakeLists.txt
 	cmake -B${BUILD_DIR} -DCMAKE_BUILD_TYPE=Debug -DCLANG_TIDY=ON -DTESTING=ON -DSANITIZERS=ON .
 
+dev-nostd: CMakeLists.txt test/CMakeLists.txt
+	cmake -B${BUILD_DIR} -DCMAKE_BUILD_TYPE=Debug -DCLANG_TIDY=ON -DTESTING=ON -DSANITIZERS=ON -DNO_ALLOC=ON .
+
 ${TEST_BIN}: ${LIB} test/*
 	cmake --build ${BUILD_DIR} --target sframe_test
 

--- a/include/sframe/map.h
+++ b/include/sframe/map.h
@@ -2,6 +2,8 @@
 
 #include <sframe/vector.h>
 
+namespace sframe {
+
 template<typename K, typename V, size_t N>
 class map : private vector<std::optional<std::pair<K, V>>, N>
 {
@@ -64,3 +66,5 @@ public:
     std::replace_if(this->begin(), this->end(), to_erase, std::nullopt);
   }
 };
+
+} // namespace sframe

--- a/include/sframe/map.h
+++ b/include/sframe/map.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#ifdef NO_ALLOC
+
 #include <sframe/vector.h>
 
 namespace sframe {
@@ -68,3 +70,35 @@ public:
 };
 
 } // namespace sframe
+
+#else // ifdef NO_ALLOC
+
+#include <map>
+
+namespace sframe {
+
+template<typename K, typename V, size_t N>
+class map : public std::map<K, V>
+{
+private:
+  using parent = std::map<K, V>;
+
+public:
+  bool contains(const K& key) const { return this->count(key) > 0; }
+
+  template<typename F>
+  void erase_if_key(F&& f)
+  {
+    for (auto iter = this->begin(); iter != this->end();) {
+      if (f(iter->first)) {
+        iter = this->erase(iter);
+      } else {
+        ++iter;
+      }
+    }
+  }
+};
+
+} // namespace sframe
+
+#endif // def NO_ALLOC

--- a/include/sframe/map.h
+++ b/include/sframe/map.h
@@ -77,6 +77,13 @@ public:
 
 namespace sframe {
 
+// NOTE: NOT RECOMMENDED FOR USE OUTSIDE THIS LIBRARY
+//
+// We have used public inheritance from std::map<T> to simplify the interface
+// here.  This works fine for the use cases we have within this library.  If you
+// choose to use this map type outside this library, you MUST NOT store it as a
+// std::map<T> pointer or reference.  This will cause memory leaks, because the
+// destructor ~std::map<T> is not virtual.
 template<typename K, typename V, size_t N>
 class map : public std::map<K, V>
 {

--- a/include/sframe/sframe.h
+++ b/include/sframe/sframe.h
@@ -6,6 +6,17 @@
 #include <sframe/map.h>
 #include <sframe/vector.h>
 
+// These constants define the size of certain internal data structures if
+// we are configured not to depend on dynamic allocations, i.e., if the NO_ALLOC
+// flag is set.  If you are using an allocator, you can ignore them.
+#ifndef SFRAME_MAX_KEYS
+#define SFRAME_MAX_KEYS 200
+#endif
+
+#ifndef SFRAME_EPOCH_BITS
+#define SFRAME_EPOCH_BITS 4
+#endif
+
 namespace sframe {
 
 struct crypto_error : std::runtime_error
@@ -58,7 +69,6 @@ using owned_bytes = vector<uint8_t, N>;
 
 using KeyID = uint64_t;
 using Counter = uint64_t;
-
 class Header;
 
 enum struct KeyUsage
@@ -106,10 +116,8 @@ public:
   static constexpr size_t max_metadata_size = 512;
 
 protected:
-  static constexpr size_t max_keys = 200;
-
   CipherSuite suite;
-  map<KeyID, KeyRecord, max_keys> keys;
+  map<KeyID, KeyRecord, SFRAME_MAX_KEYS> keys;
 
   output_bytes protect_inner(const Header& header,
                              output_bytes ciphertext,
@@ -185,8 +193,7 @@ private:
   const size_t epoch_bits;
   const size_t epoch_mask;
 
-  // XXX(RLB) Make this an attribute of the class?
-  static constexpr size_t max_epochs = 16;
+  static constexpr size_t max_epochs = 1 << SFRAME_EPOCH_BITS;
   vector<std::optional<EpochKeys>, max_epochs> epoch_cache;
 };
 

--- a/include/sframe/vector.h
+++ b/include/sframe/vector.h
@@ -103,20 +103,24 @@ private:
 public:
   constexpr vector()
     : parent(N)
-  {}
+  {
+  }
 
   constexpr vector(size_t size)
     : parent(size)
-  {}
+  {
+  }
 
   constexpr vector(gsl::span<const T> content)
     : parent(content.begin(), content.end())
-  {}
+  {
+  }
 
   template<size_t M>
   constexpr vector(const vector<T, M>& content)
     : parent(content)
-  {}
+  {
+  }
 
   void append(gsl::span<const T> content)
   {
@@ -128,4 +132,4 @@ public:
 
 } // namespace sframe
 
-#endif
+#endif // def NO_ALLOC

--- a/include/sframe/vector.h
+++ b/include/sframe/vector.h
@@ -94,6 +94,13 @@ public:
 
 namespace sframe {
 
+// NOTE: NOT RECOMMENDED FOR USE OUTSIDE THIS LIBRARY
+//
+// We have used public inheritance from std::vector<T> to simplify the interface
+// here.  This works fine for the use cases we have within this library.  If you
+// choose to use this vector type outside this library, you MUST NOT store it as
+// a std::vector<T> pointer or reference.  This will cause memory leaks, because
+// the destructor ~std::vector<T> is not virtual.
 template<typename T, size_t N>
 class vector : public std::vector<T>
 {


### PR DESCRIPTION
In #50, we didn't make the allocator optional, we made it forbidden.  This PR adds a `NO_ALLOC` flag that turns off the allocator dependency.  If that flag is enabled, we use `std::vector` and `std::map` as normal.  If it is enabled, then we use our custom, fixed-size vector/map implementations.

The main note of caution here is that we inherit from STL containers.  This is fine within the scope of this library, but can cause memory leaks in certain other situations.