### PR TITLE
Make namespaces configurable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,17 @@ option(TESTING    "Build tests" OFF)
 option(CLANG_TIDY "Perform linting with clang-tidy" OFF)
 option(SANITIZERS "Enable sanitizers" OFF)
 option(NO_ALLOC   "Build without needing an allocator" OFF)
+option(NAMESPACE_SUFFIX "Namespace Suffix for CXX and CMake Export")
+
+if(NAMESPACE_SUFFIX)
+    set(SFRAME_CXX_NAMESPACE "sframe_${NAMESPACE_SUFFIX}" CACHE STRING "Top-level Namespace for CXX")
+    set(SFRAME_EXPORT_NAMESPACE "SFrame${NAMESPACE_SUFFIX}" CACHE STRING "Namespace for CMake Export")
+else()
+    set(SFRAME_CXX_NAMESPACE "sframe" CACHE STRING "Top-level Namespace for CXX")
+    set(SFRAME_EXPORT_NAMESPACE "SFrame" CACHE STRING "Namespace for CMake Export")
+endif()
+message(STATUS "CXX Namespace: ${SFRAME_CXX_NAMESPACE}")
+message(STATUS "CMake Export Namespace: ${SFRAME_EXPORT_NAMESPACE}")
 
 # Use -DCRYPTO=(OPENSSL_1_1 | OPENSSL_3 | BORINGSSL) to configure crypto
 if(NOT DEFINED CRYPTO)
@@ -19,6 +30,12 @@ endif()
 ### Global Config
 ###
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
+
+configure_file(
+  "${CMAKE_CURRENT_SOURCE_DIR}/cmake/namespace.h.in"
+  "${CMAKE_CURRENT_BINARY_DIR}/include/namespace.h"
+  @ONLY
+)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -87,13 +104,15 @@ endif()
 set(LIB_NAME "${PROJECT_NAME}")
 
 file(GLOB_RECURSE LIB_HEADERS CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/include/*.h")
+file(GLOB_RECURSE LIB_GENERATED_HEADERS CONFIGURE_DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/include/*.h")
 file(GLOB_RECURSE LIB_SOURCES CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")
 
-add_library(${LIB_NAME} ${LIB_HEADERS} ${LIB_SOURCES})
+add_library(${LIB_NAME} ${LIB_HEADERS} ${LIB_GENERATED_HEADERS} ${LIB_SOURCES})
 target_link_libraries(${LIB_NAME} PRIVATE ${CRYPTO_LIB})
 target_include_directories(${LIB_NAME}
   PUBLIC
-    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>
     $<INSTALL_INTERFACE:include/${PROJECT_NAME}-${PROJECT_VERSION}>
 )
 

--- a/cmake/namespace.h.in
+++ b/cmake/namespace.h.in
@@ -1,0 +1,4 @@
+#pragma once
+
+// Configurable top-level namespace
+#define SFRAME_NAMESPACE @SFRAME_CXX_NAMESPACE@

--- a/include/sframe/map.h
+++ b/include/sframe/map.h
@@ -4,7 +4,7 @@
 
 #include <sframe/vector.h>
 
-namespace sframe {
+namespace SFRAME_NAMESPACE {
 
 template<typename K, typename V, size_t N>
 class map : private vector<std::optional<std::pair<K, V>>, N>
@@ -69,13 +69,14 @@ public:
   }
 };
 
-} // namespace sframe
+} // namespace SFRAME_NAMESPACE
 
 #else // ifdef NO_ALLOC
 
 #include <map>
+#include <namespace.h>
 
-namespace sframe {
+namespace SFRAME_NAMESPACE {
 
 // NOTE: NOT RECOMMENDED FOR USE OUTSIDE THIS LIBRARY
 //
@@ -106,6 +107,6 @@ public:
   }
 };
 
-} // namespace sframe
+} // namespace SFRAME_NAMESPACE
 
 #endif // def NO_ALLOC

--- a/include/sframe/sframe.h
+++ b/include/sframe/sframe.h
@@ -6,6 +6,8 @@
 #include <sframe/map.h>
 #include <sframe/vector.h>
 
+#include <namespace.h>
+
 // These constants define the size of certain internal data structures if
 // we are configured not to depend on dynamic allocations, i.e., if the NO_ALLOC
 // flag is set.  If you are using an allocator, you can ignore them.
@@ -22,7 +24,7 @@
 #define SFRAME_EPOCH_BITS 4
 #endif
 
-namespace sframe {
+namespace SFRAME_NAMESPACE {
 
 struct crypto_error : std::runtime_error
 {
@@ -202,4 +204,4 @@ private:
   vector<std::optional<EpochKeys>, max_epochs> epoch_cache;
 };
 
-} // namespace sframe
+} // namespace SFRAME_NAMESPACE

--- a/include/sframe/vector.h
+++ b/include/sframe/vector.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <namespace.h>
 #include <gsl/gsl-lite.hpp>
+#include <namespace.h>
 
 #ifdef NO_ALLOC
 

--- a/include/sframe/vector.h
+++ b/include/sframe/vector.h
@@ -1,10 +1,11 @@
 #pragma once
 
+#include <namespace.h>
 #include <gsl/gsl-lite.hpp>
 
 #ifdef NO_ALLOC
 
-namespace sframe {
+namespace SFRAME_NAMESPACE {
 
 template<typename T, size_t N>
 class vector
@@ -86,13 +87,13 @@ public:
   operator gsl::span<T>() { return gsl::span(_data).first(_size); }
 };
 
-} // namespace sframe
+} // namespace SFRAME_NAMESPACE
 
 #else // ifdef NO_ALLOC
 
 #include <vector>
 
-namespace sframe {
+namespace SFRAME_NAMESPACE {
 
 // NOTE: NOT RECOMMENDED FOR USE OUTSIDE THIS LIBRARY
 //
@@ -137,6 +138,6 @@ public:
   }
 };
 
-} // namespace sframe
+} // namespace SFRAME_NAMESPACE
 
 #endif // def NO_ALLOC

--- a/src/crypto.cpp
+++ b/src/crypto.cpp
@@ -1,7 +1,7 @@
 #include "crypto.h"
 #include "header.h"
 
-namespace sframe {
+namespace SFRAME_NAMESPACE {
 
 size_t
 cipher_digest_size(CipherSuite suite)
@@ -94,4 +94,4 @@ cipher_overhead(CipherSuite suite)
   }
 }
 
-} // namespace sframe
+} // namespace SFRAME_NAMESPACE

--- a/src/crypto.h
+++ b/src/crypto.h
@@ -2,7 +2,7 @@
 
 #include <sframe/sframe.h>
 
-namespace sframe {
+namespace SFRAME_NAMESPACE {
 
 size_t
 cipher_digest_size(CipherSuite suite);
@@ -48,4 +48,4 @@ open(CipherSuite suite,
      input_bytes aad,
      input_bytes ct);
 
-} // namespace sframe
+} // namespace SFRAME_NAMESPACE

--- a/src/crypto_boringssl.cpp
+++ b/src/crypto_boringssl.cpp
@@ -9,7 +9,7 @@
 #include <openssl/hmac.h>
 #include <openssl/mem.h>
 
-namespace sframe {
+namespace SFRAME_NAMESPACE {
 
 ///
 /// Convert between native identifiers / errors and OpenSSL ones
@@ -428,6 +428,6 @@ open(CipherSuite suite,
   throw unsupported_ciphersuite_error();
 }
 
-} // namespace sframe
+} // namespace SFRAME_NAMESPACE
 
 #endif // defined(OPENSSL_3)

--- a/src/crypto_openssl11.cpp
+++ b/src/crypto_openssl11.cpp
@@ -7,7 +7,7 @@
 #include <openssl/evp.h>
 #include <openssl/hmac.h>
 
-namespace sframe {
+namespace SFRAME_NAMESPACE {
 
 ///
 /// Scoped pointers for OpenSSL objects
@@ -466,6 +466,6 @@ open(CipherSuite suite,
   throw unsupported_ciphersuite_error();
 }
 
-} // namespace sframe
+} // namespace SFRAME_NAMESPACE
 
 #endif // defined(OPENSSL_1_1)

--- a/src/crypto_openssl3.cpp
+++ b/src/crypto_openssl3.cpp
@@ -9,7 +9,7 @@
 #include <openssl/kdf.h>
 #include <openssl/params.h>
 
-namespace sframe {
+namespace SFRAME_NAMESPACE {
 
 ///
 /// Convert between native identifiers / errors and OpenSSL ones
@@ -468,6 +468,6 @@ open(CipherSuite suite,
   throw unsupported_ciphersuite_error();
 }
 
-} // namespace sframe
+} // namespace SFRAME_NAMESPACE
 
 #endif // defined(OPENSSL_3)

--- a/src/header.cpp
+++ b/src/header.cpp
@@ -1,6 +1,6 @@
 #include "header.h"
 
-namespace sframe {
+namespace SFRAME_NAMESPACE {
 
 static size_t
 uint_size(uint64_t val)
@@ -200,4 +200,4 @@ Header::encode(output_bytes buffer) const
 }
 #endif
 
-} // namespace sframe
+} // namespace SFRAME_NAMESPACE

--- a/src/header.h
+++ b/src/header.h
@@ -2,7 +2,7 @@
 
 #include <sframe/sframe.h>
 
-namespace sframe {
+namespace SFRAME_NAMESPACE {
 
 void
 encode_uint(uint64_t val, output_bytes buffer);
@@ -31,4 +31,4 @@ private:
   Header(KeyID key_id_in, Counter counter_in, input_bytes encoded_in);
 };
 
-} // namespace sframe
+} // namespace SFRAME_NAMESPACE

--- a/src/sframe.cpp
+++ b/src/sframe.cpp
@@ -3,7 +3,7 @@
 #include "crypto.h"
 #include "header.h"
 
-namespace sframe {
+namespace SFRAME_NAMESPACE {
 
 ///
 /// Errors
@@ -378,4 +378,4 @@ MLSContext::ensure_key(KeyID key_id, KeyUsage usage)
   return;
 }
 
-} // namespace sframe
+} // namespace SFRAME_NAMESPACE

--- a/test/common.cpp
+++ b/test/common.cpp
@@ -21,7 +21,7 @@ from_hex(const std::string& hex)
 }
 
 std::string
-to_hex(const sframe::input_bytes data)
+to_hex(const SFRAME_NAMESPACE::input_bytes data)
 {
   std::stringstream hex(std::ios_base::out);
   hex.flags(std::ios::hex);

--- a/test/common.h
+++ b/test/common.h
@@ -1,5 +1,5 @@
-#include <sframe/sframe.h>
 #include <namespace.h>
+#include <sframe/sframe.h>
 
 #include <string>
 #include <vector>

--- a/test/common.h
+++ b/test/common.h
@@ -1,4 +1,5 @@
 #include <sframe/sframe.h>
+#include <namespace.h>
 
 #include <string>
 #include <vector>
@@ -8,7 +9,7 @@ using bytes = std::vector<uint8_t>;
 bytes
 from_hex(const std::string& hex);
 std::string
-to_hex(const sframe::input_bytes data);
+to_hex(const SFRAME_NAMESPACE::input_bytes data);
 
 template<typename T>
 bytes

--- a/test/header.cpp
+++ b/test/header.cpp
@@ -9,7 +9,7 @@
 #include <map>       // for map
 #include <stdexcept> // for invalid_argument
 
-using namespace sframe;
+using namespace SFRAME_NAMESPACE;
 
 TEST_CASE("Header Known-Answer")
 {

--- a/test/sframe.cpp
+++ b/test/sframe.cpp
@@ -10,7 +10,7 @@
 #include <stdexcept> // for invalid_argument
 #include <string>    // for basic_string, operator==
 
-using namespace sframe;
+using namespace SFRAME_NAMESPACE;
 
 TEST_CASE("SFrame Round-Trip")
 {

--- a/test/vectors.cpp
+++ b/test/vectors.cpp
@@ -8,7 +8,7 @@
 
 #include "common.h"
 
-using namespace sframe;
+using namespace SFRAME_NAMESPACE;
 using nlohmann::json;
 
 struct HexBytes


### PR DESCRIPTION
Following the same strategy as MLSpp, adds an optional suffix to the C++ namespace so that multiple versions can be supported in the same binary.