### PR TITLE
Fix empty bytes being nullptr empty.

### DIFF
--- a/src/sframe.cpp
+++ b/src/sframe.cpp
@@ -71,7 +71,7 @@ KeyRecord::from_base_key(CipherSuite suite,
   auto key_size = cipher_key_size(suite);
   auto nonce_size = cipher_nonce_size(suite);
 
-  const auto empty_byte_string = owned_bytes<0>();
+  const auto empty_byte_string = owned_bytes<1>();
   const auto key_label = sframe_key_label(suite, key_id);
   const auto salt_label = sframe_salt_label(suite, key_id);
 


### PR DESCRIPTION
On some machines (M2 MacOS at least), the `empty_byte_string` is actually set as a nullptr (`owned_bytes<0>` results in a nullptr), which causes openssl 3 to throw an error in `hkdf_extract`:
```
error:078C0102:common libcrypto routines::passed a null parameter
```
Changing to `owned_bytes<1>` appears to fix the issue.